### PR TITLE
Minor bug fixes and improvements to country guesser

### DIFF
--- a/web/app.vue
+++ b/web/app.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <NuxtPage />
-    <DynamicBackground />
+    <DynamicBackground v-if="showDynamicBackground" />
     <a id="seo-link" href="https://www.instagram.com/markus_vizshun/"
       >@markus_vizshun</a
     >
@@ -9,6 +9,8 @@
 </template>
 
 <script setup lang="ts">
+const showDynamicBackground = useDynamicBackgroundVisible();
+
 useSeoMeta({
   title: "Mark Metcalfe",
   ogTitle: "Mark Metcalfe",

--- a/web/components/DropdownSelect.vue
+++ b/web/components/DropdownSelect.vue
@@ -225,6 +225,11 @@ onUnmounted(() => {
   align-items: center;
   flex: auto;
 
+  @include vars.mobile-only {
+    font-size: 16px;
+    line-height: 1;
+  }
+
   &-container {
     position: relative;
     width: 100%;

--- a/web/components/LinkButton.vue
+++ b/web/components/LinkButton.vue
@@ -146,6 +146,10 @@ const handleClick = (event: MouseEvent) => {
     border: var(--color-light) 1px solid;
     text-decoration: none;
 
+    @include vars.mobile-only {
+      font-size: 16px;
+    }
+
     & svg * {
       stroke: var(--color-light);
       transition: stroke 0.4s;
@@ -168,7 +172,6 @@ const handleClick = (event: MouseEvent) => {
       }
 
       @include vars.mobile-only {
-        font-size: 1rem;
         padding: 0.5rem;
       }
     }
@@ -180,7 +183,6 @@ const handleClick = (event: MouseEvent) => {
       }
 
       @include vars.mobile-only {
-        font-size: 0.75rem;
         padding: 0.25rem;
       }
     }

--- a/web/components/RangeSlider.vue
+++ b/web/components/RangeSlider.vue
@@ -136,6 +136,10 @@ const handleBlur = (): void => {
   &-label {
     margin-right: 0.5rem;
     white-space: nowrap;
+
+    @include vars.mobile-only {
+      font-size: 16px;
+    }
   }
 
   &-container {

--- a/web/components/SectionBlock.vue
+++ b/web/components/SectionBlock.vue
@@ -94,7 +94,7 @@ withDefaults(defineProps<Props>(), {
 
     @include vars.mobile-only {
       max-width: 325px;
-      font-size: 0.9rem;
+      font-size: 16px;
       gap: 0.5rem;
     }
 

--- a/web/components/TextField.vue
+++ b/web/components/TextField.vue
@@ -16,23 +16,37 @@
         :id="id"
         ref="inputRef"
         class="textfield-field"
-        :type="type"
+        :type="effectiveType"
         :value="modelValue"
-        :placeholder="placeholder"
-        :aria-labelledby="labelId"
+        :aria-labelledby="label ? labelId : undefined"
+        :aria-label="!label ? ariaLabel : undefined"
         :disabled="disabled"
-        :autocomplete="autocomplete"
-        :spellcheck="spellcheck"
+        :name="name"
+        v-bind="autofillAttrs"
         @input="onInput"
         @focus="isFocused = true"
         @blur="isFocused = false"
       />
+      <!--
+        Rendered as an overlay rather than the input's native
+        `placeholder` attribute -- iOS Safari heuristically scans that
+        attribute for address/contact-like keywords and offers to
+        autofill the field from the user's Contacts card regardless of
+        autocomplete="off". This shows the same text with nothing for
+        that heuristic to read.
+      -->
+      <span
+        v-if="!modelValue"
+        class="textfield-visual-placeholder"
+        aria-hidden="true"
+        >{{ placeholder }}</span
+      >
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, useId } from "vue";
+import { computed, ref, useId } from "vue";
 
 type InputType =
   | "text"
@@ -40,7 +54,8 @@ type InputType =
   | "password"
   | "number"
   | "tel"
-  | "url";
+  | "url"
+  | "search";
 
 interface Props {
   modelValue?: string | number;
@@ -49,20 +64,44 @@ interface Props {
   type?: InputType;
   small?: boolean;
   disabled?: boolean;
-  autocomplete?: string;
-  spellcheck?: boolean;
+  // Native keyboard/autofill suggestions. Set to false to turn off
+  // autocomplete, spellcheck, autocorrect and autocapitalize together --
+  // callers that care about one of these almost always want all four
+  // off at once.
+  autofill?: boolean;
+  name?: string;
+  ariaLabel?: string;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   modelValue: "",
   label: null,
   placeholder: "Enter text...",
   type: "text",
   small: false,
   disabled: false,
-  autocomplete: undefined,
-  spellcheck: undefined,
+  autofill: true,
+  name: undefined,
+  ariaLabel: undefined,
 });
+
+const autofillAttrs = computed(() =>
+  props.autofill
+    ? {}
+    : {
+        autocomplete: "off",
+        spellcheck: false,
+        autocorrect: "off",
+        autocapitalize: "off",
+      },
+);
+
+// `type="search"` fields are treated differently by mobile browsers'
+// personal-data-fill heuristics than `type="text"`, so bundle it in
+// whenever autofill is turned off rather than making callers set both.
+const effectiveType = computed(() =>
+  props.autofill ? props.type : "search",
+);
 
 const emit = defineEmits<{
   "update:modelValue": [value: string | number];
@@ -113,6 +152,13 @@ defineExpose({
     font-size: inherit;
     font-weight: inherit;
 
+    // iOS Safari auto-zooms the page when focusing an input with a
+    // computed font-size under 16px; the site's mobile body font-size
+    // is smaller than that, so force it back up on every field.
+    @include vars.mobile-only {
+      font-size: 16px;
+    }
+
     &:focus {
       outline: none;
       border-color: var(--color-highlight);
@@ -123,6 +169,24 @@ defineExpose({
     padding: 0.25rem;
   }
 
+  &-visual-placeholder {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    padding: 0 calc(0.5rem + 1px);
+    color: var(--color-light);
+    opacity: 0.5;
+    pointer-events: none;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  &--small &-visual-placeholder {
+    padding: 0 calc(0.25rem + 1px);
+  }
+
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {
     appearance: none;
@@ -131,6 +195,15 @@ defineExpose({
 
   input[type="number"] {
     appearance: textfield;
+  }
+
+  input[type="search"] {
+    appearance: none;
+
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-decoration {
+      appearance: none;
+    }
   }
 }
 </style>

--- a/web/components/ToggleSwitch.vue
+++ b/web/components/ToggleSwitch.vue
@@ -60,6 +60,8 @@ const toggle = () => {
 </script>
 
 <style lang="scss">
+@use "/variables" as vars;
+
 .toggleswitch {
   display: flex;
   align-items: center;
@@ -75,6 +77,10 @@ const toggle = () => {
 
   &__label {
     white-space: nowrap;
+
+    @include vars.mobile-only {
+      font-size: 16px;
+    }
   }
 
   &-track {

--- a/web/composables/useDynamicBackground.ts
+++ b/web/composables/useDynamicBackground.ts
@@ -1,0 +1,17 @@
+const hidden = ref(false);
+
+// app.vue reads this to decide whether to mount the generative background.
+export function useDynamicBackgroundVisible() {
+  return computed(() => !hidden.value);
+}
+
+// Pages with their own opaque full-viewport background call this to hide
+// (and unmount, saving GPU/battery) the generative one behind them.
+export function useHideDynamicBackground() {
+  onMounted(() => {
+    hidden.value = true;
+  });
+  onUnmounted(() => {
+    hidden.value = false;
+  });
+}

--- a/web/modules/countries/components/AttractMap.vue
+++ b/web/modules/countries/components/AttractMap.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="attractmap">
+  <div v-if="!isPlaywrightTest" class="attractmap">
     <CountryMap
       :target-code="targetCode"
       :guessed-codes="[]"
@@ -17,6 +17,11 @@ import { COUNTRIES } from "../data/countries";
 // background always looks mid-transition rather than settling fully.
 const CYCLE_INTERVAL_MS = 7000;
 
+// This map's continuous random cycling/zooming makes it unsuitable to
+// appear in Chromatic snapshots (never the same frame twice), so it's
+// skipped entirely under Playwright/Chromatic runs.
+const isPlaywrightTest = useRuntimeConfig().public.isPlaywrightTest;
+
 const targetCode = ref<string | null>(null);
 let timer: ReturnType<typeof setInterval> | undefined;
 
@@ -32,6 +37,9 @@ function focusRandomCountry() {
 }
 
 onMounted(() => {
+  if (isPlaywrightTest) {
+    return;
+  }
   focusRandomCountry();
   timer = setInterval(focusRandomCountry, CYCLE_INTERVAL_MS);
 });

--- a/web/modules/countries/components/GuessInput.vue
+++ b/web/modules/countries/components/GuessInput.vue
@@ -1,14 +1,24 @@
 <template>
-  <div class="guessinput">
+  <div
+    class="guessinput"
+    @focusin="startResetScroll"
+    @focusout="stopResetScroll"
+  >
     <p class="guessinput-hint">{{ hint || " " }}</p>
-    <form class="guessinput-form" @submit.prevent="handleSubmit">
+    <form
+      class="guessinput-form"
+      autocomplete="off"
+      @submit.prevent="handleSubmit"
+    >
       <TextField
+        ref="textFieldRef"
         v-model="text"
         class="guessinput-field"
         :class="{ 'guessinput-field-shake': shake }"
+        name="guess"
+        aria-label="Guess"
         placeholder="Type a country..."
-        autocomplete="off"
-        :spellcheck="false"
+        :autofill="false"
         :disabled="disabled"
       />
       <LinkButton
@@ -22,7 +32,7 @@
         v-if="showSkip"
         text="Skip"
         :disabled="disabled"
-        @click="emit('skip')"
+        @click="handleSkip"
       >
         <Icon name="bx:skip-next" />
       </LinkButton>
@@ -50,7 +60,31 @@ const emit = defineEmits<{
 
 const text = ref("");
 const shake = ref(false);
+const textFieldRef = ref<{ focus: () => void }>();
 
+// Mobile browsers scroll a focused input into view while the on-screen
+// keyboard opens/animates, which on this fixed-layout page just reveals
+// dead space below it. That scroll can happen at any point during the
+// keyboard's open animation, so a single reset can still land before it
+// -- keep re-snapping to the top on an interval for as long as the
+// field stays focused instead of just once.
+let resetScrollInterval: ReturnType<typeof setInterval> | undefined;
+
+function startResetScroll() {
+  window.scrollTo(0, 0);
+  clearInterval(resetScrollInterval);
+  resetScrollInterval = setInterval(() => {
+    window.scrollTo(0, 0);
+  }, 100);
+}
+
+function stopResetScroll() {
+  clearInterval(resetScrollInterval);
+}
+
+// Guess/Skip are buttons, so clicking either moves focus away from the
+// text field and closes the on-screen keyboard. Immediately refocusing
+// keeps it open so the next guess can be typed straight away.
 function handleSubmit() {
   const value = text.value.trim();
   if (!value) {
@@ -58,6 +92,12 @@ function handleSubmit() {
   }
   emit("submit", value);
   text.value = "";
+  textFieldRef.value?.focus();
+}
+
+function handleSkip() {
+  emit("skip");
+  textFieldRef.value?.focus();
 }
 
 function flashIncorrect() {
@@ -69,6 +109,14 @@ function flashIncorrect() {
     }, 300);
   });
 }
+
+onMounted(() => {
+  textFieldRef.value?.focus();
+});
+
+onUnmounted(() => {
+  clearInterval(resetScrollInterval);
+});
 
 defineExpose({ flashIncorrect });
 </script>

--- a/web/modules/countries/components/RoomLobby.vue
+++ b/web/modules/countries/components/RoomLobby.vue
@@ -81,6 +81,8 @@ function copyLink() {
 </script>
 
 <style lang="scss">
+@use "/variables" as vars;
+
 .roomlobby {
   position: relative;
   z-index: 0;
@@ -131,12 +133,21 @@ function copyLink() {
 
     &-url {
       flex: 1;
+      min-width: 0;
       font-size: 0.8rem;
       color: var(--color-light);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       text-align: left;
+    }
+  }
+
+  @include vars.mobile-only {
+    padding: 1.25rem 1rem;
+
+    &-invite {
+      max-width: none;
     }
   }
 

--- a/web/modules/countries/composables/useCountryGuesserSound.ts
+++ b/web/modules/countries/composables/useCountryGuesserSound.ts
@@ -69,9 +69,9 @@ export function useCountryGuesserSound(
       oscillator: { type: "triangle" },
       envelope: {
         attack: 0.02,
-        decay: 0.2,
+        decay: 0.15,
         sustain: 0.1,
-        release: 0.5,
+        release: 0.4,
       },
     }).toDestination();
     roundEndSynth.volume.value = -8;
@@ -137,9 +137,10 @@ export function useCountryGuesserSound(
       return;
     }
     const now = toneRef.now();
-    roundEndSynth.triggerAttackRelease("E5", "8n", now);
-    roundEndSynth.triggerAttackRelease("G5", "8n", now + 0.12);
-    roundEndSynth.triggerAttackRelease("C6", "4n", now + 0.24);
+    roundEndSynth.triggerAttackRelease("C5", "8n", now);
+    roundEndSynth.triggerAttackRelease("E5", "8n", now + 0.12);
+    roundEndSynth.triggerAttackRelease("G5", "8n", now + 0.24);
+    roundEndSynth.triggerAttackRelease("C6", "2n", now + 0.36);
   }
 
   // Multiplayer only: everyone has guessed or skipped, moving on to

--- a/web/modules/countries/composables/useFixMobileViewport.ts
+++ b/web/modules/countries/composables/useFixMobileViewport.ts
@@ -1,0 +1,71 @@
+// Applies everything needed to make a full-viewport `position: fixed`
+// game page behave on mobile once the on-screen keyboard opens.
+export function useFixMobileViewport(
+  varName = "--cg-viewport-height",
+) {
+  // The site otherwise has no viewport meta tag at all. Without one,
+  // mobile browsers fall back to scrolling/panning the page to bring a
+  // focused input above the on-screen keyboard, which is exactly the
+  // "scrolls to dead space" bug this fixes -- `interactive-widget=resizes-
+  // content` instead shrinks the visual viewport around the keyboard,
+  // which the height tracking below already reacts to correctly.
+  useHead({
+    meta: [
+      {
+        name: "viewport",
+        content:
+          "width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content",
+      },
+    ],
+  });
+
+  // Opening the on-screen keyboard on mobile shrinks the *visual*
+  // viewport but typically leaves the *layout* viewport untouched, so
+  // elements sized with `position: fixed; inset: 0` (or `height: 100vh`)
+  // don't shrink and end up partly hidden behind the keyboard. Track the
+  // visual viewport's height on a CSS custom property so callers can
+  // size against it instead.
+  function syncHeight() {
+    const height =
+      window.visualViewport?.height ?? window.innerHeight;
+    document.documentElement.style.setProperty(
+      varName,
+      `${height}px`,
+    );
+  }
+
+  // Mobile browsers also scroll the document to bring a focused input
+  // into view, which on these full-viewport `position: fixed` game pages
+  // just reveals dead space below the fixed layout (there's nothing to
+  // actually scroll to). `overflow: hidden` alone doesn't stop this on
+  // iOS Safari -- it still scrolls the layout viewport on focus
+  // regardless. Pinning the body itself with `position: fixed` removes
+  // any scrollable surface for it to scroll to, which is the technique
+  // that actually works there.
+  let previousOverflow = "";
+  let previousPosition = "";
+  let previousWidth = "";
+
+  onMounted(() => {
+    syncHeight();
+    window.visualViewport?.addEventListener("resize", syncHeight);
+    window.addEventListener("resize", syncHeight);
+
+    previousOverflow = document.body.style.overflow;
+    previousPosition = document.body.style.position;
+    previousWidth = document.body.style.width;
+    document.body.style.overflow = "hidden";
+    document.body.style.position = "fixed";
+    document.body.style.width = "100%";
+  });
+
+  onUnmounted(() => {
+    window.visualViewport?.removeEventListener("resize", syncHeight);
+    window.removeEventListener("resize", syncHeight);
+    document.documentElement.style.removeProperty(varName);
+
+    document.body.style.overflow = previousOverflow;
+    document.body.style.position = previousPosition;
+    document.body.style.width = previousWidth;
+  });
+}

--- a/web/modules/countries/pages/countries/[roomId].vue
+++ b/web/modules/countries/pages/countries/[roomId].vue
@@ -107,7 +107,8 @@
           v-model="nameValue"
           maxlength="24"
           placeholder="Your name..."
-          autocomplete="off"
+          aria-label="Your name"
+          :autofill="false"
         />
         <LinkButton
           :disabled="!nameValue.trim().length"
@@ -133,6 +134,10 @@ useSeoMeta({
     "A singleplayer and multiplayer country name guessing game",
   ogImage: "https://markmetcalfe.com/countries/social-card.jpg?v=1",
 });
+
+useHideDynamicBackground();
+
+useFixMobileViewport();
 
 const route = useRoute();
 const config = useRuntimeConfig();
@@ -245,7 +250,10 @@ onUnmounted(() => {
 
 .countryguesserroom {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--cg-viewport-height, 100dvh);
   display: grid;
   grid-template: "header" auto "main" 1fr / 1fr;
   background: var(--color-dark);

--- a/web/modules/countries/pages/countries/index.vue
+++ b/web/modules/countries/pages/countries/index.vue
@@ -103,6 +103,10 @@ useSeoMeta({
   ogImage: "https://markmetcalfe.com/countries/social-card.jpg?v=1",
 });
 
+useHideDynamicBackground();
+
+useFixMobileViewport();
+
 const store = useCountryGuesserStore();
 const { playCorrect, playIncorrect, playRoundEnd } =
   useCountryGuesserSound(
@@ -165,7 +169,10 @@ onUnmounted(() => {
 
 .countryguesser {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--cg-viewport-height, 100dvh);
   display: grid;
   grid-template: "header" auto "main" 1fr / 1fr;
   background: var(--color-dark);

--- a/web/modules/countries/stores/countryGuesserRoom.ts
+++ b/web/modules/countries/stores/countryGuesserRoom.ts
@@ -61,6 +61,22 @@ export interface RoomEvent {
 // WebSocket must not be wrapped in Vue reactivity (breaks the object).
 let _ws: WebSocket | null = null;
 
+// Connection details kept outside store state (like `_ws`) purely so
+// reconnect logic can re-dial without the caller passing them again.
+let _roomId: string | null = null;
+let _apiBase = "";
+let _manualDisconnect = true;
+let _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+const RECONNECT_DELAY_MS = 1500;
+
+// Mobile browsers (iOS Safari in particular) frequently suspend or drop
+// WebSocket connections when the tab is backgrounded or the screen locks
+// -- e.g. the host switching apps to paste the room link into a messaging
+// app. Without reconnecting, that client silently stops receiving further
+// broadcasts (including other players joining) until a manual reload.
+let _visibilityHandler: (() => void) | null = null;
+let _pageshowHandler: (() => void) | null = null;
+
 export const useCountryGuesserRoomStore = defineStore(
   "countryGuesserRoom",
   {
@@ -90,11 +106,46 @@ export const useCountryGuesserRoomStore = defineStore(
     actions: {
       connect(roomId: string, apiBase: string) {
         this._closeWs();
-        const wsBase = apiBase
-          ? apiBase.replace(/^http/, "ws")
+        _roomId = roomId;
+        _apiBase = apiBase;
+        _manualDisconnect = false;
+        this._dial();
+
+        if (!_visibilityHandler) {
+          _visibilityHandler = () => {
+            if (
+              document.visibilityState === "visible" &&
+              !_manualDisconnect &&
+              _ws?.readyState !== WebSocket.OPEN &&
+              _ws?.readyState !== WebSocket.CONNECTING
+            ) {
+              this._dial();
+            }
+          };
+          document.addEventListener(
+            "visibilitychange",
+            _visibilityHandler,
+          );
+        }
+        if (!_pageshowHandler) {
+          _pageshowHandler = () => _visibilityHandler?.();
+          window.addEventListener("pageshow", _pageshowHandler);
+        }
+      },
+
+      _dial() {
+        if (!_roomId) {
+          return;
+        }
+        if (_reconnectTimer) {
+          clearTimeout(_reconnectTimer);
+          _reconnectTimer = null;
+        }
+        const wsBase = _apiBase
+          ? _apiBase.replace(/^http/, "ws")
           : `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}`;
         const socket = new WebSocket(
-          `${wsBase}/api/countries/ws/${roomId}`,
+          `${wsBase}/api/countries/ws/${_roomId}`,
         );
 
         socket.addEventListener("message", event => {
@@ -111,11 +162,34 @@ export const useCountryGuesserRoomStore = defineStore(
         });
         socket.addEventListener("close", () => {
           this.connected = false;
+          if (!_manualDisconnect && !_reconnectTimer) {
+            _reconnectTimer = setTimeout(() => {
+              _reconnectTimer = null;
+              this._dial();
+            }, RECONNECT_DELAY_MS);
+          }
         });
         _ws = socket;
       },
 
       disconnect() {
+        _manualDisconnect = true;
+        if (_visibilityHandler) {
+          document.removeEventListener(
+            "visibilitychange",
+            _visibilityHandler,
+          );
+          _visibilityHandler = null;
+        }
+        if (_pageshowHandler) {
+          window.removeEventListener("pageshow", _pageshowHandler);
+          _pageshowHandler = null;
+        }
+        if (_reconnectTimer) {
+          clearTimeout(_reconnectTimer);
+          _reconnectTimer = null;
+        }
+        _roomId = null;
         this._closeWs();
         this._resetState();
       },
@@ -141,6 +215,7 @@ export const useCountryGuesserRoomStore = defineStore(
       },
 
       submitSkip() {
+        this.lastGuessCorrect = false;
         this.send({ type: "skip" });
       },
 
@@ -200,6 +275,7 @@ export const useCountryGuesserRoomStore = defineStore(
             this.hint = msg.hint;
             this.guessedCodes = msg.guessedCodes;
             this.donePlayerIds = [];
+            this.lastGuessCorrect = null;
             break;
 
           case "hint_update":

--- a/web/modules/countries/tests/e2e/country-guesser.spec.ts
+++ b/web/modules/countries/tests/e2e/country-guesser.spec.ts
@@ -26,7 +26,10 @@ test.describe("CountryGuesserPage", () => {
       page.locator("text=/ \\/ 197 guessed/"),
     ).toBeVisible();
     await expect(
-      page.locator('input[placeholder="Type a country..."]'),
+      page.getByRole("searchbox", { name: "Guess" }),
+    ).toBeVisible();
+    await expect(
+      page.locator('text="Type a country..."'),
     ).toBeVisible();
   });
 });

--- a/web/modules/doodle/components/DoodleChat.vue
+++ b/web/modules/doodle/components/DoodleChat.vue
@@ -17,8 +17,9 @@
       <TextField
         v-model="inputText"
         :placeholder="inputPlaceholder"
+        aria-label="Chat message"
         maxlength="100"
-        autocomplete="off"
+        :autofill="false"
         @keydown.enter="submit"
       />
       <LinkButton @click="submit">

--- a/web/modules/doodle/components/DoodleLobby.vue
+++ b/web/modules/doodle/components/DoodleLobby.vue
@@ -28,6 +28,7 @@
       <TextField
         v-model="wordInput"
         placeholder="Suggest a word to draw…"
+        aria-label="Suggest a word"
         :disabled="store.iHaveSubmittedWord"
       />
       <LinkButton

--- a/web/modules/doodle/pages/doodle/[room].vue
+++ b/web/modules/doodle/pages/doodle/[room].vue
@@ -55,7 +55,8 @@
           v-model="nameValue"
           maxlength="24"
           placeholder="Your name..."
-          autocomplete="off"
+          aria-label="Your name"
+          :autofill="false"
         />
         <LinkButton
           :disabled="!nameValue.trim().length"
@@ -79,6 +80,8 @@ useSeoMeta({
   ogDescription: "A multiplayer drawing and guessing game",
   ogImage: "https://markmetcalfe.com/doodle/social-card.jpg?v=1",
 });
+
+useHideDynamicBackground();
 
 const route = useRoute();
 const config = useRuntimeConfig();

--- a/web/modules/doodle/pages/doodle/index.vue
+++ b/web/modules/doodle/pages/doodle/index.vue
@@ -11,6 +11,8 @@ useSeoMeta({
   ogImage: "https://markmetcalfe.com/doodle/social-card.jpg?v=1",
 });
 
+useHideDynamicBackground();
+
 onBeforeMount(async () => {
   const res = await fetch("/api/doodle/rooms", { method: "POST" });
   const { roomId } = (await res.json()) as { roomId: string };

--- a/web/modules/sequencer/components/BpmFader.vue
+++ b/web/modules/sequencer/components/BpmFader.vue
@@ -44,6 +44,10 @@ defineProps<Props>();
       color: var(--color-highlight);
       border: var(--color-highlight) 1px solid;
     }
+
+    @include vars.mobile-only {
+      padding: 0.3rem 0.4rem;
+    }
   }
 }
 </style>

--- a/web/modules/sequencer/pages/sequencer/index.vue
+++ b/web/modules/sequencer/pages/sequencer/index.vue
@@ -266,12 +266,15 @@ onUnmounted(() => {
       }
 
       @include vars.mobile-only {
-        font-size: 0.75rem;
         min-width: 4.5rem;
         padding-right: 0.25rem;
 
+        & .dropdownselect {
+          font-size: 0.75rem;
+        }
+
         & .dropdownselect-selected-option {
-          padding: 0.1rem 0.5rem;
+          padding: 0.2rem 0.5rem;
         }
 
         & .dropdownselect-option {

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -24,6 +24,11 @@ export default defineNuxtConfig({
     "@pinia/nuxt",
   ],
   devtools: { enabled: true },
+  runtimeConfig: {
+    public: {
+      isPlaywrightTest,
+    },
+  },
   app: {
     head: {
       title: "Mark Metcalfe",

--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -61,6 +61,14 @@
         <Icon name="fad:waveform" />
       </LinkButton>
       <LinkButton
+        text="Country Guesser"
+        href="/countries"
+        large
+        class="country-guesser"
+      >
+        <Icon name="bx:world" />
+      </LinkButton>
+      <LinkButton
         v-if="!isMobile()"
         text="Doodle"
         href="/doodle"
@@ -178,6 +186,16 @@ const { mailtoLink } = useAppConfig();
           color: var(--color-highlight);
         }
       }
+    }
+  }
+
+  .country-guesser a {
+    @include vars.desktop-only {
+      font-size: 1.25rem;
+    }
+
+    @include vars.mobile-only {
+      font-size: 0.85rem;
     }
   }
 }


### PR DESCRIPTION
General fixes/improvements:
- Add Country Guesser link to the homepage
- Swapped the end-of-game sound for the more celebratory one used in the Doodle game
- Fixed "Nice job!" wrongly appearing after skipping a country instead of guessing it correctly
- Removed the distracting animated background behind the game while playing
- Fixed flaky automated screenshot tests caused by that same background

Mobile specific fixes:
- Made the room-invite link box wide enough to read fully on mobile
- Fixed multiplayer sometimes not showing new players joining on mobile (auto-reconnects if the connection drops)
- Fixed the map being hidden behind the on-screen keyboard on mobile
- Stopped the keyboard's "autofill contact" popup from covering the guess box
- Stopped the page zooming in when tapping the guess box
- Stopped the page scrolling down to blank space when the keyboard opens
- Keyboard now stays open between guesses instead of closing after each one
- Guess box is now auto-focused as soon as a round starts