### PR TITLE
Update network status route to be /api/network-status

### DIFF
--- a/api/network-status/src/index.ts
+++ b/api/network-status/src/index.ts
@@ -13,7 +13,10 @@ export default {
     );
     const dnsData = (await dnsResponse.json()) as DNSResponse;
     const homeIp = dnsData.Answer[0].data;
-    const isConnected = visitorIp === homeIp || visitorIp === "::1";
+    const isConnected =
+      visitorIp === homeIp ||
+      visitorIp === "::1" ||
+      visitorIp === "127.0.0.1";
 
     const response = {
       isConnected,

--- a/api/network-status/wrangler.jsonc
+++ b/api/network-status/wrangler.jsonc
@@ -6,7 +6,7 @@
   "preview_urls": false,
   "routes": [
     {
-      "pattern": "markmetcalfe.com/api/get-network-status",
+      "pattern": "markmetcalfe.com/api/network-status",
       "zone_name": "markmetcalfe.com",
     },
   ],

--- a/web/modules/network-status/pages/status.vue
+++ b/web/modules/network-status/pages/status.vue
@@ -43,7 +43,7 @@ const {
   data: networkStatus,
   status,
   refresh,
-} = await useFetch<NetworkStatus>("/api/get-network-status", {
+} = await useFetch<NetworkStatus>("/api/network-status", {
   server: false,
 });
 </script>

--- a/web/modules/network-status/tests/e2e/status.spec.ts
+++ b/web/modules/network-status/tests/e2e/status.spec.ts
@@ -28,7 +28,7 @@ test.describe("NetworkStatusPage", () => {
   test("can see connected network status", async ({
     page,
   }, testInfo) => {
-    await page.route("/api/get-network-status", async route => {
+    await page.route("/api/network-status", async route => {
       await route.fulfill({
         status: 200,
         body: JSON.stringify({
@@ -65,7 +65,7 @@ test.describe("NetworkStatusPage", () => {
   test("can see not connected network status", async ({
     page,
   }, testInfo) => {
-    await page.route("/api/get-network-status", async route => {
+    await page.route("/api/network-status", async route => {
       await route.fulfill({
         status: 200,
         body: JSON.stringify({
@@ -91,7 +91,7 @@ test.describe("NetworkStatusPage", () => {
   });
 
   test("can refresh the network status", async ({ page }) => {
-    await page.route("/api/get-network-status", async route => {
+    await page.route("/api/network-status", async route => {
       await route.fulfill({
         status: 200,
         body: JSON.stringify({
@@ -110,7 +110,7 @@ test.describe("NetworkStatusPage", () => {
       "Not Connected To Local Network",
     );
 
-    await page.route("/api/get-network-status", async route => {
+    await page.route("/api/network-status", async route => {
       await route.fulfill({
         status: 200,
         body: JSON.stringify({


### PR DESCRIPTION
Renames the route from `/api/get-network-status` to `/api/network-status` to be consistent with the other APIs