### PR TITLE
Add more renovate groupings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,14 @@
   "minimumReleaseAge": "14 days",
   "packageRules": [
     {
+      "description": "Refresh @markmetcalfe lockfile pins every hour instead of waiting for weekly lock file maintenance",
+      "matchFileNames": ["web/**"],
+      "matchPackageNames": ["@markmetcalfe/*"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": null,
+      "schedule": ["* * * * *"]
+    },
+    {
       "description": "Update @markmetcalfe packages every hour",
       "matchFileNames": ["web/**"],
       "matchPackageNames": ["@markmetcalfe/*"],
@@ -52,8 +60,31 @@
     },
     {
       "matchFileNames": ["web/**"],
-      "matchPackageNames": ["/@nuxt/"],
+      "matchPackageNames": ["nuxt", "/@nuxt/"],
       "groupName": "web nuxt"
+    },
+    {
+      "matchFileNames": ["web/**"],
+      "matchPackageNames": ["/^stylelint/"],
+      "groupName": "stylelint"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    },
+    {
+      "matchFileNames": ["web/**"],
+      "matchPackageNames": ["pinia", "/@pinia/"],
+      "groupName": "pinia"
+    },
+    {
+      "matchFileNames": ["web/**"],
+      "matchPackageNames": ["maplibre-gl", "/@maplibre/"],
+      "groupName": "maplibre"
+    },
+    {
+      "matchPackageNames": ["@chromatic-com/playwright", "@playwright/test"],
+      "groupName": "playwright"
     }
   ],
   "hostRules": [


### PR DESCRIPTION
Adds more package grouping rules to the renovate config, to reduce dependency update noise.
Also adds an extra grouping for @markmetcalfe/* packages, so patch releases get made on a faster schedule.