### PR TITLE
Improve country guesser UX and add multiplayer country-order setting

### DIFF
--- a/api/countries/src/countries.ts
+++ b/api/countries/src/countries.ts
@@ -4,6 +4,8 @@ export interface Country {
   code: string;
   name: string;
   aliases: string[];
+  population: number;
+  area: number;
 }
 
 export const COUNTRIES: Country[] = countriesData;

--- a/api/countries/src/game-room.ts
+++ b/api/countries/src/game-room.ts
@@ -4,6 +4,7 @@ import type {
   RoomState,
   ClientMessage,
   ServerMessage,
+  CountryOrder,
 } from "./types";
 import { COUNTRIES, isCorrectGuess, type Country } from "./countries";
 import { containsProfanity } from "../../shared/profanity";
@@ -19,7 +20,11 @@ interface GameData {
   phase: RoomPhase;
   mode: "multiplayer" | "solo";
   players: Player[];
+  // Doubles as the host's live lobby pick while `phase === "waiting"`
+  // (see "update_settings" below) so a non-host player can see what's
+  // selected, and as the actual round length once a round starts.
   roundLength: number;
+  countryOrder: CountryOrder;
   timeLeft: number;
   // Epoch ms the current/most recent round began, purely to compute
   // `lastRoundElapsedSeconds` -- never shown to clients directly, since
@@ -48,6 +53,8 @@ interface GameData {
 }
 
 const CLUE_INTERVAL_SECONDS = 5;
+// See the `clueIntervalSeconds` getter below.
+const PLAYWRIGHT_CLUE_INTERVAL_SECONDS = 9999;
 const CLUE_REVEAL_CAP = 0.6;
 const AUTO_ADVANCE_GRACE_SECONDS = 8;
 // See the `autoAdvanceGraceSeconds` getter below.
@@ -81,21 +88,54 @@ const PLAYWRIGHT_GRACE_PERIOD_MS = 0;
 // bonus or penalty to speed it up) in real time.
 const PLAYWRIGHT_TICK_SPEEDUP = 4;
 
-// Playwright hardcodes guesses against the round order (see
-// `IS_PLAYWRIGHT` below), so its queue is alphabetical by name instead
-// of shuffled.
-function shuffledCodes(alphabetical: boolean): string[] {
-  if (alphabetical) {
-    return [...COUNTRIES]
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map(c => c.code);
-  }
+const VALID_COUNTRY_ORDERS: CountryOrder[] = [
+  "random",
+  "alphabetical",
+  "population",
+  "size",
+];
+
+function alphabeticalCodes(): string[] {
+  return [...COUNTRIES]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(c => c.code);
+}
+
+function shuffledCodes(): string[] {
   const codes = COUNTRIES.map(c => c.code);
   for (let i = codes.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [codes[i], codes[j]] = [codes[j] as string, codes[i] as string];
   }
   return codes;
+}
+
+// Playwright hardcodes guesses against the round order (see
+// `IS_PLAYWRIGHT` below), so "random" falls back to the same alphabetical
+// queue as before instead of a real shuffle -- an explicitly chosen order
+// is always honoured deterministically regardless, since a lobby test
+// picks one of these on purpose to verify it actually took effect.
+function queueForOrder(
+  order: CountryOrder,
+  alphabeticalUnderPlaywright: boolean,
+): string[] {
+  switch (order) {
+    case "alphabetical":
+      return alphabeticalCodes();
+    case "population":
+      return [...COUNTRIES]
+        .sort((a, b) => b.population - a.population)
+        .map(c => c.code);
+    case "size":
+      return [...COUNTRIES]
+        .sort((a, b) => b.area - a.area)
+        .map(c => c.code);
+    case "random":
+    default:
+      return alphabeticalUnderPlaywright
+        ? alphabeticalCodes()
+        : shuffledCodes();
+  }
 }
 
 function countryByCode(code: string): Country | undefined {
@@ -162,12 +202,41 @@ export class GameRoom implements DurableObject {
       : AUTO_ADVANCE_GRACE_SECONDS;
   }
 
+  // A clue reveal racing a test's own guess/skip clicks makes a guess's
+  // score (100 down to a floor of 20, 10 off per letter already
+  // revealed) depend on real click speed, same class of problem as
+  // `autoAdvanceGraceSeconds` above -- and a Chromatic game-over
+  // snapshot then flags every run as a visual diff since the displayed
+  // score differs. Widened past any realistic test's target dwell time
+  // so no clue ever reveals under Playwright at all.
+  private get clueIntervalSeconds(): number {
+    return this.env.IS_PLAYWRIGHT === "1"
+      ? PLAYWRIGHT_CLUE_INTERVAL_SECONDS
+      : CLUE_INTERVAL_SECONDS;
+  }
+
+  // Solo's clock is otherwise driven by two independent sources at once
+  // under Playwright: this per-tick decrement firing on a real-world
+  // schedule, and the test's own skip/guess clicks each nudging
+  // `timeLeft` by a fixed amount. Racing the two makes both the final
+  // "X skipped" count and the elapsed-time readout on the game-over
+  // screen vary run to run (Chromatic then flags every run as a visual
+  // diff). Multiplayer has no such race -- it has no skip/guess time
+  // penalty/bonus to fight with -- and still needs the passive tick to
+  // ever end a round, so this only ever suppresses solo's tick.
+  private get soloClockIsManual(): boolean {
+    return (
+      this.game.mode === "solo" && this.env.IS_PLAYWRIGHT === "1"
+    );
+  }
+
   private makeInitialState(): GameData {
     return {
       phase: "waiting",
       mode: "multiplayer",
       players: [],
       roundLength: 300,
+      countryOrder: "random",
       timeLeft: 0,
       roundStartedAt: 0,
       lastRoundElapsedSeconds: 0,
@@ -243,7 +312,9 @@ export class GameRoom implements DurableObject {
       }
       return;
     }
-    this.game.timeLeft--;
+    if (!this.soloClockIsManual) {
+      this.game.timeLeft--;
+    }
     if (this.game.timeLeft <= 0) {
       this.doEndRound();
       return;
@@ -446,7 +517,16 @@ export class GameRoom implements DurableObject {
               MAX_ROUND_LENGTH,
               Math.max(MIN_ROUND_LENGTH, msg.round_length ?? 300),
             );
-        this.doStartGame(roundLength, solo ? "solo" : "multiplayer");
+        const countryOrder = VALID_COUNTRY_ORDERS.includes(
+          msg.country_order as CountryOrder,
+        )
+          ? (msg.country_order as CountryOrder)
+          : "random";
+        this.doStartGame(
+          roundLength,
+          solo ? "solo" : "multiplayer",
+          countryOrder,
+        );
         break;
       }
 
@@ -539,6 +619,35 @@ export class GameRoom implements DurableObject {
         this.broadcast({ type: "returned_to_lobby" });
         break;
       }
+
+      // Lets a non-host player see the host's current picks live rather
+      // than only finding out once the round starts -- host-only and
+      // lobby-only for the same reason "start_game" is: nobody else
+      // should be able to change what the room's about to play.
+      case "update_settings": {
+        if (
+          !session.player ||
+          !session.player.isHost ||
+          this.game.phase !== "waiting"
+        ) {
+          return;
+        }
+        this.game.roundLength = Math.min(
+          MAX_ROUND_LENGTH,
+          Math.max(MIN_ROUND_LENGTH, msg.round_length),
+        );
+        this.game.countryOrder = VALID_COUNTRY_ORDERS.includes(
+          msg.country_order,
+        )
+          ? msg.country_order
+          : "random";
+        this.broadcast({
+          type: "settings_update",
+          round_length: this.game.roundLength,
+          country_order: this.game.countryOrder,
+        });
+        break;
+      }
     }
   }
 
@@ -605,12 +714,16 @@ export class GameRoom implements DurableObject {
   private doStartGame(
     roundLength: number,
     mode: "multiplayer" | "solo",
+    countryOrder: CountryOrder,
   ): void {
     this.game.mode = mode;
     this.game.roundLength = roundLength;
     this.game.timeLeft = roundLength;
     this.game.roundStartedAt = Date.now();
-    this.game.queue = shuffledCodes(this.env.IS_PLAYWRIGHT === "1");
+    this.game.queue = queueForOrder(
+      countryOrder,
+      this.env.IS_PLAYWRIGHT === "1",
+    );
     this.game.guessedCodes = [];
     this.game.players.forEach(p => {
       p.score = 0;
@@ -630,14 +743,14 @@ export class GameRoom implements DurableObject {
     if (!country) {
       return;
     }
-    if (this.game.targetElapsed % CLUE_INTERVAL_SECONDS === 0) {
+    if (this.game.targetElapsed % this.clueIntervalSeconds === 0) {
       this.revealLetter(country);
     }
     const cap = Math.ceil(
       letterCount(country.name) * CLUE_REVEAL_CAP,
     );
     const autoAdvanceAt =
-      cap * CLUE_INTERVAL_SECONDS + this.autoAdvanceGraceSeconds;
+      cap * this.clueIntervalSeconds + this.autoAdvanceGraceSeconds;
     // Safety net: force the room on even if some players never guessed
     // or skipped (e.g. gone AFK), so a stuck player can't block everyone
     // forever. Solo has no one else to block, so let the target sit
@@ -669,9 +782,15 @@ export class GameRoom implements DurableObject {
     if (hidden.length === 0) {
       return;
     }
-    const idx = hidden[
-      Math.floor(Math.random() * hidden.length)
-    ] as number;
+    // `hidden` is built in ascending index order, so under Playwright
+    // this always reveals the earliest unrevealed letter first (1st,
+    // then 2nd, etc.) instead of a random one -- otherwise Chromatic
+    // sees a different hint string on every run.
+    const idx = (
+      this.env.IS_PLAYWRIGHT === "1"
+        ? hidden[0]
+        : hidden[Math.floor(Math.random() * hidden.length)]
+    ) as number;
     this.game.revealedIndices.push(idx);
     this.broadcast({
       type: "hint_update",
@@ -716,9 +835,15 @@ export class GameRoom implements DurableObject {
     // its fresh "state" sync too, instead of the last-played country
     // re-triggering CountryMap's zoom-in/pull-back-out tween.
     this.game.currentCode = "";
-    this.game.lastRoundElapsedSeconds = Math.round(
-      (Date.now() - this.game.roundStartedAt) / 1000,
-    );
+    // Real elapsed wall time for everyone else, but that's exactly the
+    // quantity `soloClockIsManual` stops being deterministic once the
+    // passive tick is suppressed -- so derive it from the round's own
+    // bookkeeping instead: how much of `roundLength` got used up by
+    // skip penalties and guess bonuses, the only things still moving
+    // the clock in that mode.
+    this.game.lastRoundElapsedSeconds = this.soloClockIsManual
+      ? this.game.roundLength - this.game.timeLeft
+      : Math.round((Date.now() - this.game.roundStartedAt) / 1000);
     this.scheduleIdleAlarm();
     const sorted = [...this.game.players].sort(
       (a, b) => b.score - a.score,
@@ -765,6 +890,7 @@ export class GameRoom implements DurableObject {
       mode: this.game.mode,
       players: this.game.players,
       roundLength: this.game.roundLength,
+      countryOrder: this.game.countryOrder,
       timeLeft: this.game.timeLeft,
       elapsedSeconds: this.game.lastRoundElapsedSeconds,
       currentCode: this.game.currentCode,

--- a/api/countries/src/types.ts
+++ b/api/countries/src/types.ts
@@ -13,11 +13,18 @@ export interface Player {
 
 export type RoomPhase = "waiting" | "playing" | "round_end";
 
+export type CountryOrder =
+  | "random"
+  | "alphabetical"
+  | "population"
+  | "size";
+
 export interface RoomState {
   phase: RoomPhase;
   mode: "multiplayer" | "solo";
   players: Player[];
   roundLength: number;
+  countryOrder: CountryOrder;
   timeLeft: number;
   // How long the most recently finished round actually took, wall-clock
   // -- server-computed so a client reconnecting straight into
@@ -33,11 +40,21 @@ export interface RoomState {
 
 export type ClientMessage =
   | { type: "join"; id: string; name: string }
-  | { type: "start_game"; round_length?: number; solo?: boolean }
+  | {
+      type: "start_game";
+      round_length?: number;
+      solo?: boolean;
+      country_order?: CountryOrder;
+    }
   | { type: "guess"; text: string }
   | { type: "skip" }
   | { type: "submit_score" }
-  | { type: "return_to_lobby" };
+  | { type: "return_to_lobby" }
+  | {
+      type: "update_settings";
+      round_length: number;
+      country_order: CountryOrder;
+    };
 
 export type ServerMessage =
   | { type: "state"; state: RoomState }
@@ -82,4 +99,9 @@ export type ServerMessage =
   | { type: "score_submitted" }
   | { type: "error"; message: string }
   | { type: "ping" }
-  | { type: "returned_to_lobby" };
+  | { type: "returned_to_lobby" }
+  | {
+      type: "settings_update";
+      round_length: number;
+      country_order: CountryOrder;
+    };

--- a/shared/countries.json
+++ b/shared/countries.json
@@ -2,229 +2,315 @@
   {
     "code": "af",
     "name": "Afghanistan",
-    "aliases": []
+    "aliases": [],
+    "population": 43844111,
+    "area": 652230
   },
   {
     "code": "al",
     "name": "Albania",
-    "aliases": []
+    "aliases": [],
+    "population": 2349580,
+    "area": 28748
   },
   {
     "code": "dz",
     "name": "Algeria",
-    "aliases": []
+    "aliases": [],
+    "population": 47435312,
+    "area": 2381741
   },
   {
     "code": "ad",
     "name": "Andorra",
-    "aliases": []
+    "aliases": [],
+    "population": 82904,
+    "area": 468
   },
   {
     "code": "ao",
     "name": "Angola",
-    "aliases": []
+    "aliases": [],
+    "population": 39040039,
+    "area": 1246700
   },
   {
     "code": "ag",
     "name": "Antigua and Barbuda",
-    "aliases": []
+    "aliases": [],
+    "population": 94209,
+    "area": 442
   },
   {
     "code": "ar",
     "name": "Argentina",
-    "aliases": []
+    "aliases": [],
+    "population": 45851378,
+    "area": 2780400
   },
   {
     "code": "am",
     "name": "Armenia",
-    "aliases": []
+    "aliases": [],
+    "population": 3086700,
+    "area": 29743
   },
   {
     "code": "au",
     "name": "Australia",
-    "aliases": []
+    "aliases": [],
+    "population": 27614411,
+    "area": 7692024
   },
   {
     "code": "at",
     "name": "Austria",
-    "aliases": []
+    "aliases": [],
+    "population": 9208163,
+    "area": 83871
   },
   {
     "code": "az",
     "name": "Azerbaijan",
-    "aliases": []
+    "aliases": [],
+    "population": 10246996,
+    "area": 86600
   },
   {
     "code": "bs",
     "name": "Bahamas",
     "aliases": [
       "The Bahamas"
-    ]
+    ],
+    "population": 403033,
+    "area": 13943
   },
   {
     "code": "bh",
     "name": "Bahrain",
-    "aliases": []
+    "aliases": [],
+    "population": 1600366,
+    "area": 765
   },
   {
     "code": "bd",
     "name": "Bangladesh",
-    "aliases": []
+    "aliases": [],
+    "population": 175686899,
+    "area": 147570
   },
   {
     "code": "bb",
     "name": "Barbados",
-    "aliases": []
+    "aliases": [],
+    "population": 282623,
+    "area": 430
   },
   {
     "code": "by",
     "name": "Belarus",
-    "aliases": []
+    "aliases": [],
+    "population": 9085991,
+    "area": 207600
   },
   {
     "code": "be",
     "name": "Belgium",
-    "aliases": []
+    "aliases": [],
+    "population": 11941781,
+    "area": 30528
   },
   {
     "code": "bz",
     "name": "Belize",
-    "aliases": []
+    "aliases": [],
+    "population": 422924,
+    "area": 22966
   },
   {
     "code": "bj",
     "name": "Benin",
-    "aliases": []
+    "aliases": [],
+    "population": 14814460,
+    "area": 112622
   },
   {
     "code": "bt",
     "name": "Bhutan",
-    "aliases": []
+    "aliases": [],
+    "population": 796682,
+    "area": 38394
   },
   {
     "code": "bo",
     "name": "Bolivia",
-    "aliases": []
+    "aliases": [],
+    "population": 12581843,
+    "area": 1098581
   },
   {
     "code": "ba",
     "name": "Bosnia and Herzegovina",
     "aliases": [
       "Bosnia"
-    ]
+    ],
+    "population": 3140095,
+    "area": 51209
   },
   {
     "code": "bw",
     "name": "Botswana",
-    "aliases": []
+    "aliases": [],
+    "population": 2562122,
+    "area": 582000
   },
   {
     "code": "br",
     "name": "Brazil",
-    "aliases": []
+    "aliases": [],
+    "population": 212812405,
+    "area": 8515767
   },
   {
     "code": "bn",
     "name": "Brunei",
     "aliases": [
       "Brunei Darussalam"
-    ]
+    ],
+    "population": 466330,
+    "area": 5765
   },
   {
     "code": "bg",
     "name": "Bulgaria",
-    "aliases": []
+    "aliases": [],
+    "population": 6433302,
+    "area": 110879
   },
   {
     "code": "bf",
     "name": "Burkina Faso",
-    "aliases": []
+    "aliases": [],
+    "population": 24074580,
+    "area": 272967
   },
   {
     "code": "bi",
     "name": "Burundi",
-    "aliases": []
+    "aliases": [],
+    "population": 14390003,
+    "area": 27834
   },
   {
     "code": "kh",
     "name": "Cambodia",
-    "aliases": []
+    "aliases": [],
+    "population": 17847982,
+    "area": 181035
   },
   {
     "code": "cm",
     "name": "Cameroon",
-    "aliases": []
+    "aliases": [],
+    "population": 29879337,
+    "area": 475442
   },
   {
     "code": "ca",
     "name": "Canada",
-    "aliases": []
+    "aliases": [],
+    "population": 41651653,
+    "area": 9984670
   },
   {
     "code": "cv",
     "name": "Cape Verde",
     "aliases": [
       "Cabo Verde"
-    ]
+    ],
+    "population": 527326,
+    "area": 4033
   },
   {
     "code": "cf",
     "name": "Central African Republic",
-    "aliases": []
+    "aliases": [],
+    "population": 5513282,
+    "area": 622984
   },
   {
     "code": "td",
     "name": "Chad",
-    "aliases": []
+    "aliases": [],
+    "population": 21003705,
+    "area": 1284000
   },
   {
     "code": "cl",
     "name": "Chile",
-    "aliases": []
+    "aliases": [],
+    "population": 19859921,
+    "area": 756102
   },
   {
     "code": "cn",
     "name": "China",
     "aliases": [
       "People's Republic of China"
-    ]
+    ],
+    "population": 1406585000,
+    "area": 9706961
   },
   {
     "code": "co",
     "name": "Colombia",
-    "aliases": []
+    "aliases": [],
+    "population": 53425635,
+    "area": 1141748
   },
   {
     "code": "km",
     "name": "Comoros",
-    "aliases": []
+    "aliases": [],
+    "population": 882847,
+    "area": 1862
   },
   {
     "code": "cr",
     "name": "Costa Rica",
-    "aliases": []
+    "aliases": [],
+    "population": 5152950,
+    "area": 51100
   },
   {
     "code": "hr",
     "name": "Croatia",
-    "aliases": []
+    "aliases": [],
+    "population": 3876200,
+    "area": 56594
   },
   {
     "code": "cu",
     "name": "Cuba",
-    "aliases": []
+    "aliases": [],
+    "population": 10937203,
+    "area": 109884
   },
   {
     "code": "cy",
     "name": "Cyprus",
-    "aliases": []
+    "aliases": [],
+    "population": 1370754,
+    "area": 9251
   },
   {
     "code": "cz",
     "name": "Czechia",
     "aliases": [
       "Czech Republic"
-    ]
+    ],
+    "population": 10886878,
+    "area": 78865
   },
   {
     "code": "cd",
@@ -233,515 +319,711 @@
       "DR Congo",
       "Congo-Kinshasa",
       "DRC"
-    ]
+    ],
+    "population": 112832473,
+    "area": 2344858
   },
   {
     "code": "dk",
     "name": "Denmark",
-    "aliases": []
+    "aliases": [],
+    "population": 6009169,
+    "area": 43094
   },
   {
     "code": "dj",
     "name": "Djibouti",
-    "aliases": []
+    "aliases": [],
+    "population": 1184076,
+    "area": 23200
   },
   {
     "code": "dm",
     "name": "Dominica",
-    "aliases": []
+    "aliases": [],
+    "population": 65871,
+    "area": 751
   },
   {
     "code": "do",
     "name": "Dominican Republic",
-    "aliases": []
+    "aliases": [],
+    "population": 11520487,
+    "area": 48671
   },
   {
     "code": "ec",
     "name": "Ecuador",
-    "aliases": []
+    "aliases": [],
+    "population": 18289896,
+    "area": 276841
   },
   {
     "code": "eg",
     "name": "Egypt",
-    "aliases": []
+    "aliases": [],
+    "population": 118365995,
+    "area": 1002450
   },
   {
     "code": "sv",
     "name": "El Salvador",
-    "aliases": []
+    "aliases": [],
+    "population": 6365503,
+    "area": 21041
   },
   {
     "code": "gq",
     "name": "Equatorial Guinea",
-    "aliases": []
+    "aliases": [],
+    "population": 1938431,
+    "area": 28051
   },
   {
     "code": "er",
     "name": "Eritrea",
-    "aliases": []
+    "aliases": [],
+    "population": 3607003,
+    "area": 117600
   },
   {
     "code": "ee",
     "name": "Estonia",
-    "aliases": []
+    "aliases": [],
+    "population": 1366475,
+    "area": 45227
   },
   {
     "code": "sz",
     "name": "Eswatini",
     "aliases": [
       "Swaziland"
-    ]
+    ],
+    "population": 1256174,
+    "area": 17364
   },
   {
     "code": "et",
     "name": "Ethiopia",
-    "aliases": []
+    "aliases": [],
+    "population": 135472051,
+    "area": 1104300
   },
   {
     "code": "fj",
     "name": "Fiji",
-    "aliases": []
+    "aliases": [],
+    "population": 933154,
+    "area": 18272
   },
   {
     "code": "fi",
     "name": "Finland",
-    "aliases": []
+    "aliases": [],
+    "population": 5646436,
+    "area": 338424
   },
   {
     "code": "fr",
     "name": "France",
-    "aliases": []
+    "aliases": [],
+    "population": 68720337,
+    "area": 551695
   },
   {
     "code": "ga",
     "name": "Gabon",
-    "aliases": []
+    "aliases": [],
+    "population": 2593130,
+    "area": 267668
   },
   {
     "code": "gm",
     "name": "Gambia",
     "aliases": [
       "The Gambia"
-    ]
+    ],
+    "population": 2822093,
+    "area": 10689
   },
   {
     "code": "ge",
     "name": "Georgia",
-    "aliases": []
+    "aliases": [],
+    "population": 3935766,
+    "area": 69700
   },
   {
     "code": "de",
     "name": "Germany",
-    "aliases": []
+    "aliases": [],
+    "population": 83491249,
+    "area": 357114
   },
   {
     "code": "gh",
     "name": "Ghana",
-    "aliases": []
+    "aliases": [],
+    "population": 35064272,
+    "area": 238533
   },
   {
     "code": "gr",
     "name": "Greece",
-    "aliases": []
+    "aliases": [],
+    "population": 10413962,
+    "area": 131990
   },
   {
     "code": "gd",
     "name": "Grenada",
-    "aliases": []
+    "aliases": [],
+    "population": 117303,
+    "area": 344
   },
   {
     "code": "gt",
     "name": "Guatemala",
-    "aliases": []
+    "aliases": [],
+    "population": 18687881,
+    "area": 108889
   },
   {
     "code": "gn",
     "name": "Guinea",
-    "aliases": []
+    "aliases": [],
+    "population": 15099727,
+    "area": 245857
   },
   {
     "code": "gw",
     "name": "Guinea-Bissau",
-    "aliases": []
+    "aliases": [],
+    "population": 2249515,
+    "area": 36125
   },
   {
     "code": "gy",
     "name": "Guyana",
-    "aliases": []
+    "aliases": [],
+    "population": 835986,
+    "area": 214969
   },
   {
     "code": "ht",
     "name": "Haiti",
-    "aliases": []
+    "aliases": [],
+    "population": 11906095,
+    "area": 27750
   },
   {
     "code": "hn",
     "name": "Honduras",
-    "aliases": []
+    "aliases": [],
+    "population": 11005850,
+    "area": 112492
   },
   {
     "code": "hu",
     "name": "Hungary",
-    "aliases": []
+    "aliases": [],
+    "population": 9514251,
+    "area": 93028
   },
   {
     "code": "is",
     "name": "Iceland",
-    "aliases": []
+    "aliases": [],
+    "population": 392404,
+    "area": 103000
   },
   {
     "code": "in",
     "name": "India",
-    "aliases": []
+    "aliases": [],
+    "population": 1463865525,
+    "area": 3287590
   },
   {
     "code": "id",
     "name": "Indonesia",
-    "aliases": []
+    "aliases": [],
+    "population": 285721236,
+    "area": 1904569
   },
   {
     "code": "ir",
     "name": "Iran",
-    "aliases": []
+    "aliases": [],
+    "population": 92417681,
+    "area": 1648195
   },
   {
     "code": "iq",
     "name": "Iraq",
-    "aliases": []
+    "aliases": [],
+    "population": 47020774,
+    "area": 438317
   },
   {
     "code": "ie",
     "name": "Ireland",
-    "aliases": []
+    "aliases": [],
+    "population": 5484367,
+    "area": 70273
   },
   {
     "code": "il",
     "name": "Israel",
-    "aliases": []
+    "aliases": [],
+    "population": 10122800,
+    "area": 20770
   },
   {
     "code": "it",
     "name": "Italy",
-    "aliases": []
+    "aliases": [],
+    "population": 58915656,
+    "area": 301336
   },
   {
     "code": "ci",
     "name": "Ivory Coast",
     "aliases": [
       "Cote d'Ivoire",
-      "Côte d'Ivoire"
-    ]
+      "C\u00f4te d'Ivoire"
+    ],
+    "population": 32711547,
+    "area": 322463
   },
   {
     "code": "jm",
     "name": "Jamaica",
-    "aliases": []
+    "aliases": [],
+    "population": 2837077,
+    "area": 10991
   },
   {
     "code": "jp",
     "name": "Japan",
-    "aliases": []
+    "aliases": [],
+    "population": 123366734,
+    "area": 377930
   },
   {
     "code": "jo",
     "name": "Jordan",
-    "aliases": []
+    "aliases": [],
+    "population": 11520684,
+    "area": 89342
   },
   {
     "code": "kz",
     "name": "Kazakhstan",
-    "aliases": []
+    "aliases": [],
+    "population": 20843754,
+    "area": 2724900
   },
   {
     "code": "ke",
     "name": "Kenya",
-    "aliases": []
+    "aliases": [],
+    "population": 57532493,
+    "area": 580367
   },
   {
     "code": "ki",
     "name": "Kiribati",
-    "aliases": []
+    "aliases": [],
+    "population": 136488,
+    "area": 811
   },
   {
     "code": "xk",
     "name": "Kosovo",
-    "aliases": []
+    "aliases": [],
+    "population": 1576876,
+    "area": 10908
   },
   {
     "code": "kw",
     "name": "Kuwait",
-    "aliases": []
+    "aliases": [],
+    "population": 4865298,
+    "area": 17818
   },
   {
     "code": "kg",
     "name": "Kyrgyzstan",
-    "aliases": []
+    "aliases": [],
+    "population": 7343064,
+    "area": 199951
   },
   {
     "code": "la",
     "name": "Laos",
     "aliases": [
       "Lao People's Democratic Republic"
-    ]
+    ],
+    "population": 7873046,
+    "area": 236800
   },
   {
     "code": "lv",
     "name": "Latvia",
-    "aliases": []
+    "aliases": [],
+    "population": 1847785,
+    "area": 64559
   },
   {
     "code": "lb",
     "name": "Lebanon",
-    "aliases": []
+    "aliases": [],
+    "population": 5849421,
+    "area": 10452
   },
   {
     "code": "ls",
     "name": "Lesotho",
-    "aliases": []
+    "aliases": [],
+    "population": 2363325,
+    "area": 30355
   },
   {
     "code": "lr",
     "name": "Liberia",
-    "aliases": []
+    "aliases": [],
+    "population": 5731206,
+    "area": 111369
   },
   {
     "code": "ly",
     "name": "Libya",
-    "aliases": []
+    "aliases": [],
+    "population": 7458555,
+    "area": 1759540
   },
   {
     "code": "li",
     "name": "Liechtenstein",
-    "aliases": []
+    "aliases": [],
+    "population": 41024,
+    "area": 160
   },
   {
     "code": "lt",
     "name": "Lithuania",
-    "aliases": []
+    "aliases": [],
+    "population": 2888774,
+    "area": 65300
   },
   {
     "code": "lu",
     "name": "Luxembourg",
-    "aliases": []
+    "aliases": [],
+    "population": 686970,
+    "area": 2586
   },
   {
     "code": "mg",
     "name": "Madagascar",
-    "aliases": []
+    "aliases": [],
+    "population": 32740678,
+    "area": 587041
   },
   {
     "code": "mw",
     "name": "Malawi",
-    "aliases": []
+    "aliases": [],
+    "population": 22216120,
+    "area": 118484
   },
   {
     "code": "my",
     "name": "Malaysia",
-    "aliases": []
+    "aliases": [],
+    "population": 35977838,
+    "area": 330803
   },
   {
     "code": "mv",
     "name": "Maldives",
-    "aliases": []
+    "aliases": [],
+    "population": 529676,
+    "area": 300
   },
   {
     "code": "ml",
     "name": "Mali",
-    "aliases": []
+    "aliases": [],
+    "population": 25198821,
+    "area": 1240192
   },
   {
     "code": "mt",
     "name": "Malta",
-    "aliases": []
+    "aliases": [],
+    "population": 579704,
+    "area": 316
   },
   {
     "code": "mh",
     "name": "Marshall Islands",
-    "aliases": []
+    "aliases": [],
+    "population": 36282,
+    "area": 181
   },
   {
     "code": "mr",
     "name": "Mauritania",
-    "aliases": []
+    "aliases": [],
+    "population": 5315065,
+    "area": 1030700
   },
   {
     "code": "mu",
     "name": "Mauritius",
-    "aliases": []
+    "aliases": [],
+    "population": 1243741,
+    "area": 2040
   },
   {
     "code": "mx",
     "name": "Mexico",
-    "aliases": []
+    "aliases": [],
+    "population": 131946900,
+    "area": 1964375
   },
   {
     "code": "fm",
     "name": "Micronesia",
     "aliases": [
       "Federated States of Micronesia"
-    ]
+    ],
+    "population": 113683,
+    "area": 702
   },
   {
     "code": "md",
     "name": "Moldova",
-    "aliases": []
+    "aliases": [],
+    "population": 2360527,
+    "area": 33846
   },
   {
     "code": "mc",
     "name": "Monaco",
-    "aliases": []
+    "aliases": [],
+    "population": 38341,
+    "area": 2.02
   },
   {
     "code": "mn",
     "name": "Mongolia",
-    "aliases": []
+    "aliases": [],
+    "population": 3568978,
+    "area": 1564110
   },
   {
     "code": "me",
     "name": "Montenegro",
-    "aliases": []
+    "aliases": [],
+    "population": 623129,
+    "area": 13812
   },
   {
     "code": "ma",
     "name": "Morocco",
-    "aliases": []
+    "aliases": [],
+    "population": 38430770,
+    "area": 446550
   },
   {
     "code": "mz",
     "name": "Mozambique",
-    "aliases": []
+    "aliases": [],
+    "population": 35631653,
+    "area": 801590
   },
   {
     "code": "mm",
     "name": "Myanmar",
     "aliases": [
       "Burma"
-    ]
+    ],
+    "population": 54850648,
+    "area": 676578
   },
   {
     "code": "na",
     "name": "Namibia",
-    "aliases": []
+    "aliases": [],
+    "population": 3092816,
+    "area": 825615
   },
   {
     "code": "nr",
     "name": "Nauru",
-    "aliases": []
+    "aliases": [],
+    "population": 12025,
+    "area": 21
   },
   {
     "code": "np",
     "name": "Nepal",
-    "aliases": []
+    "aliases": [],
+    "population": 29618118,
+    "area": 147181
   },
   {
     "code": "nl",
     "name": "Netherlands",
     "aliases": [
       "Holland"
-    ]
+    ],
+    "population": 18087633,
+    "area": 41850
   },
   {
     "code": "nz",
     "name": "New Zealand",
     "aliases": [
       "Aotearoa"
-    ]
+    ],
+    "population": 5324700,
+    "area": 270467
   },
   {
     "code": "ni",
     "name": "Nicaragua",
-    "aliases": []
+    "aliases": [],
+    "population": 7007502,
+    "area": 130373
   },
   {
     "code": "ne",
     "name": "Niger",
-    "aliases": []
+    "aliases": [],
+    "population": 27917831,
+    "area": 1267000
   },
   {
     "code": "ng",
     "name": "Nigeria",
-    "aliases": []
+    "aliases": [],
+    "population": 237527782,
+    "area": 923768
   },
   {
     "code": "kp",
     "name": "North Korea",
     "aliases": [
       "Democratic People's Republic of Korea"
-    ]
+    ],
+    "population": 26571036,
+    "area": 120538
   },
   {
     "code": "mk",
     "name": "North Macedonia",
     "aliases": [
       "Macedonia"
-    ]
+    ],
+    "population": 1820909,
+    "area": 25713
   },
   {
     "code": "no",
     "name": "Norway",
-    "aliases": []
+    "aliases": [],
+    "population": 5610870,
+    "area": 323802
   },
   {
     "code": "om",
     "name": "Oman",
-    "aliases": []
+    "aliases": [],
+    "population": 5494691,
+    "area": 309500
   },
   {
     "code": "pk",
     "name": "Pakistan",
-    "aliases": []
+    "aliases": [],
+    "population": 255219554,
+    "area": 881912
   },
   {
     "code": "pw",
     "name": "Palau",
-    "aliases": []
+    "aliases": [],
+    "population": 17663,
+    "area": 459
   },
   {
     "code": "ps",
     "name": "Palestine",
     "aliases": [
       "State of Palestine"
-    ]
+    ],
+    "population": 5413596,
+    "area": 6220
   },
   {
     "code": "pa",
     "name": "Panama",
-    "aliases": []
+    "aliases": [],
+    "population": 4571189,
+    "area": 75417
   },
   {
     "code": "pg",
     "name": "Papua New Guinea",
-    "aliases": []
+    "aliases": [],
+    "population": 10762817,
+    "area": 462840
   },
   {
     "code": "py",
     "name": "Paraguay",
-    "aliases": []
+    "aliases": [],
+    "population": 7013078,
+    "area": 406752
   },
   {
     "code": "pe",
     "name": "Peru",
-    "aliases": []
+    "aliases": [],
+    "population": 34576665,
+    "area": 1285216
   },
   {
     "code": "ph",
     "name": "Philippines",
-    "aliases": []
+    "aliases": [],
+    "population": 116786962,
+    "area": 342353
   },
   {
     "code": "pl",
     "name": "Poland",
-    "aliases": []
+    "aliases": [],
+    "population": 36435861,
+    "area": 312679
   },
   {
     "code": "pt",
     "name": "Portugal",
-    "aliases": []
+    "aliases": [],
+    "population": 10804871,
+    "area": 92090
   },
   {
     "code": "qa",
     "name": "Qatar",
-    "aliases": []
+    "aliases": [],
+    "population": 2972215,
+    "area": 11586
   },
   {
     "code": "cg",
@@ -749,49 +1031,69 @@
     "aliases": [
       "Congo",
       "Congo-Brazzaville"
-    ]
+    ],
+    "population": 6484437,
+    "area": 342000
   },
   {
     "code": "ro",
     "name": "Romania",
-    "aliases": []
+    "aliases": [],
+    "population": 19020271,
+    "area": 238391
   },
   {
     "code": "ru",
     "name": "Russia",
     "aliases": [
       "Russian Federation"
-    ]
+    ],
+    "population": 143513328,
+    "area": 17098242
   },
   {
     "code": "rw",
     "name": "Rwanda",
-    "aliases": []
+    "aliases": [],
+    "population": 14569341,
+    "area": 26338
   },
   {
     "code": "kn",
     "name": "Saint Kitts and Nevis",
-    "aliases": []
+    "aliases": [],
+    "population": 46922,
+    "area": 261
   },
   {
     "code": "lc",
     "name": "Saint Lucia",
-    "aliases": []
+    "aliases": [],
+    "population": 180149,
+    "area": 616
   },
   {
     "code": "vc",
     "name": "Saint Vincent and the Grenadines",
-    "aliases": ["St Vincent and the Grenadines"]
+    "aliases": [
+      "St Vincent and the Grenadines"
+    ],
+    "population": 99924,
+    "area": 389
   },
   {
     "code": "ws",
     "name": "Samoa",
-    "aliases": []
+    "aliases": [],
+    "population": 219306,
+    "area": 2842
   },
   {
     "code": "sm",
     "name": "San Marino",
-    "aliases": []
+    "aliases": [],
+    "population": 34109,
+    "area": 61
   },
   {
     "code": "st",
@@ -799,62 +1101,86 @@
     "aliases": [
       "Sao Tome e Principe",
       "Sao Tome"
-    ]
+    ],
+    "population": 240254,
+    "area": 964
   },
   {
     "code": "sa",
     "name": "Saudi Arabia",
-    "aliases": []
+    "aliases": [],
+    "population": 36973555,
+    "area": 2149690
   },
   {
     "code": "sn",
     "name": "Senegal",
-    "aliases": []
+    "aliases": [],
+    "population": 18931966,
+    "area": 196722
   },
   {
     "code": "rs",
     "name": "Serbia",
-    "aliases": []
+    "aliases": [],
+    "population": 6549143,
+    "area": 88361
   },
   {
     "code": "sc",
     "name": "Seychelles",
-    "aliases": []
+    "aliases": [],
+    "population": 122730,
+    "area": 452
   },
   {
     "code": "sl",
     "name": "Sierra Leone",
-    "aliases": []
+    "aliases": [],
+    "population": 8819794,
+    "area": 71740
   },
   {
     "code": "sg",
     "name": "Singapore",
-    "aliases": []
+    "aliases": [],
+    "population": 6111175,
+    "area": 710
   },
   {
     "code": "sk",
     "name": "Slovakia",
-    "aliases": []
+    "aliases": [],
+    "population": 5413813,
+    "area": 49037
   },
   {
     "code": "si",
     "name": "Slovenia",
-    "aliases": []
+    "aliases": [],
+    "population": 2130986,
+    "area": 20273
   },
   {
     "code": "sb",
     "name": "Solomon Islands",
-    "aliases": []
+    "aliases": [],
+    "population": 838645,
+    "area": 28896
   },
   {
     "code": "so",
     "name": "Somalia",
-    "aliases": []
+    "aliases": [],
+    "population": 19654739,
+    "area": 637657
   },
   {
     "code": "za",
     "name": "South Africa",
-    "aliases": []
+    "aliases": [],
+    "population": 64747319,
+    "area": 1221037
   },
   {
     "code": "kr",
@@ -862,133 +1188,181 @@
     "aliases": [
       "Korea",
       "Republic of Korea"
-    ]
+    ],
+    "population": 51684564,
+    "area": 100210
   },
   {
     "code": "ss",
     "name": "South Sudan",
-    "aliases": []
+    "aliases": [],
+    "population": 12188788,
+    "area": 619745
   },
   {
     "code": "es",
     "name": "Spain",
-    "aliases": []
+    "aliases": [],
+    "population": 49355143,
+    "area": 505992
   },
   {
     "code": "lk",
     "name": "Sri Lanka",
-    "aliases": []
+    "aliases": [],
+    "population": 21756000,
+    "area": 65610
   },
   {
     "code": "sd",
     "name": "Sudan",
-    "aliases": []
+    "aliases": [],
+    "population": 51662147,
+    "area": 1886068
   },
   {
     "code": "sr",
     "name": "Suriname",
-    "aliases": []
+    "aliases": [],
+    "population": 639850,
+    "area": 163820
   },
   {
     "code": "se",
     "name": "Sweden",
-    "aliases": []
+    "aliases": [],
+    "population": 10596620,
+    "area": 450295
   },
   {
     "code": "ch",
     "name": "Switzerland",
-    "aliases": []
+    "aliases": [],
+    "population": 9092436,
+    "area": 41284
   },
   {
     "code": "sy",
     "name": "Syria",
     "aliases": [
       "Syrian Arab Republic"
-    ]
+    ],
+    "population": 25620427,
+    "area": 185180
   },
   {
     "code": "tw",
     "name": "Taiwan",
-    "aliases": []
+    "aliases": [],
+    "population": 23400000,
+    "area": 36193
   },
   {
     "code": "tj",
     "name": "Tajikistan",
-    "aliases": []
+    "aliases": [],
+    "population": 10786734,
+    "area": 143100
   },
   {
     "code": "tz",
     "name": "Tanzania",
     "aliases": [
       "United Republic of Tanzania"
-    ]
+    ],
+    "population": 70545865,
+    "area": 945087
   },
   {
     "code": "th",
     "name": "Thailand",
-    "aliases": []
+    "aliases": [],
+    "population": 71619863,
+    "area": 513120
   },
   {
     "code": "tl",
     "name": "Timor-Leste",
     "aliases": [
       "East Timor"
-    ]
+    ],
+    "population": 1418517,
+    "area": 14874
   },
   {
     "code": "tg",
     "name": "Togo",
-    "aliases": []
+    "aliases": [],
+    "population": 8591626,
+    "area": 56785
   },
   {
     "code": "to",
     "name": "Tonga",
-    "aliases": []
+    "aliases": [],
+    "population": 103742,
+    "area": 747
   },
   {
     "code": "tt",
     "name": "Trinidad and Tobago",
-    "aliases": []
+    "aliases": [],
+    "population": 1367764,
+    "area": 5130
   },
   {
     "code": "tn",
     "name": "Tunisia",
-    "aliases": []
+    "aliases": [],
+    "population": 12348573,
+    "area": 163610
   },
   {
     "code": "tr",
     "name": "Turkey",
     "aliases": [
       "Turkiye",
-      "Türkiye"
-    ]
+      "T\u00fcrkiye"
+    ],
+    "population": 85878556,
+    "area": 783562
   },
   {
     "code": "tm",
     "name": "Turkmenistan",
-    "aliases": []
+    "aliases": [],
+    "population": 7618847,
+    "area": 488100
   },
   {
     "code": "tv",
     "name": "Tuvalu",
-    "aliases": []
+    "aliases": [],
+    "population": 9492,
+    "area": 26
   },
   {
     "code": "ug",
     "name": "Uganda",
-    "aliases": []
+    "aliases": [],
+    "population": 51384894,
+    "area": 241550
   },
   {
     "code": "ua",
     "name": "Ukraine",
-    "aliases": []
+    "aliases": [],
+    "population": 38980376,
+    "area": 603500
   },
   {
     "code": "ae",
     "name": "United Arab Emirates",
     "aliases": [
       "UAE"
-    ]
+    ],
+    "population": 11513149,
+    "area": 83600
   },
   {
     "code": "gb",
@@ -997,7 +1371,9 @@
       "UK",
       "Great Britain",
       "Britain"
-    ]
+    ],
+    "population": 69487000,
+    "area": 242900
   },
   {
     "code": "us",
@@ -1007,22 +1383,30 @@
       "USA",
       "US",
       "America"
-    ]
+    ],
+    "population": 341784857,
+    "area": 9372610
   },
   {
     "code": "uy",
     "name": "Uruguay",
-    "aliases": []
+    "aliases": [],
+    "population": 3384688,
+    "area": 181034
   },
   {
     "code": "uz",
     "name": "Uzbekistan",
-    "aliases": []
+    "aliases": [],
+    "population": 37053428,
+    "area": 447400
   },
   {
     "code": "vu",
     "name": "Vanuatu",
-    "aliases": []
+    "aliases": [],
+    "population": 335169,
+    "area": 12189
   },
   {
     "code": "va",
@@ -1030,31 +1414,43 @@
     "aliases": [
       "Holy See",
       "Vatican"
-    ]
+    ],
+    "population": 764,
+    "area": 0.44
   },
   {
     "code": "ve",
     "name": "Venezuela",
-    "aliases": []
+    "aliases": [],
+    "population": 28516896,
+    "area": 916445
   },
   {
     "code": "vn",
     "name": "Vietnam",
-    "aliases": []
+    "aliases": [],
+    "population": 101598527,
+    "area": 331212
   },
   {
     "code": "ye",
     "name": "Yemen",
-    "aliases": []
+    "aliases": [],
+    "population": 41773878,
+    "area": 527968
   },
   {
     "code": "zm",
     "name": "Zambia",
-    "aliases": []
+    "aliases": [],
+    "population": 21913874,
+    "area": 752612
   },
   {
     "code": "zw",
     "name": "Zimbabwe",
-    "aliases": []
+    "aliases": [],
+    "population": 16950795,
+    "area": 390757
   }
 ]

--- a/web/components/DropdownSelect.vue
+++ b/web/components/DropdownSelect.vue
@@ -20,6 +20,7 @@
       :aria-disabled="disabled"
       :aria-controls="listboxId"
       :aria-expanded="isOpen"
+      :aria-labelledby="label ? labelId : undefined"
       aria-haspopup="listbox"
       @keydown.space.prevent="toggleDropdown"
       @keydown.enter.prevent="toggleDropdown"

--- a/web/composables/useDynamicBackground.ts
+++ b/web/composables/useDynamicBackground.ts
@@ -7,11 +7,20 @@ export function useDynamicBackgroundVisible() {
 }
 
 // Pages with their own opaque full-viewport background call this to hide
-// (and unmount, saving GPU/battery) the generative one behind them.
-export function useHideDynamicBackground() {
-  onMounted(() => {
-    hidden.value = true;
-  });
+// (and unmount, saving GPU/battery) the generative one behind them. Hides
+// immediately by default; pass `false` (e.g. a ref that flips true once a
+// slower-loading replacement background has actually rendered) to defer
+// hiding until then, avoiding a flash of nothing in between.
+export function useHideDynamicBackground(
+  shouldHide: MaybeRefOrGetter<boolean> = true,
+) {
+  watch(
+    () => toValue(shouldHide),
+    value => {
+      hidden.value = value;
+    },
+    { immediate: true },
+  );
   onUnmounted(() => {
     hidden.value = false;
   });

--- a/web/modules/countries/components/CountryMap.vue
+++ b/web/modules/countries/components/CountryMap.vue
@@ -552,6 +552,7 @@ onMounted(async () => {
       startZoomOutAnimation();
     }
     mapLoaded.value = true;
+    useMapReady().value = true;
   });
 
   resizeObserver = new ResizeObserver(() => map?.resize());

--- a/web/modules/countries/components/GuessInput.vue
+++ b/web/modules/countries/components/GuessInput.vue
@@ -124,7 +124,10 @@ onUnmounted(() => {
   clearInterval(resetScrollInterval);
 });
 
-defineExpose({ flashIncorrect });
+defineExpose({
+  flashIncorrect,
+  focus: () => textFieldRef.value?.focus(),
+});
 </script>
 
 <style lang="scss">

--- a/web/modules/countries/components/GuessPanel.vue
+++ b/web/modules/countries/components/GuessPanel.vue
@@ -28,8 +28,23 @@
 <script setup lang="ts">
 const store = useCountryGuesserRoomStore();
 
-const guessInputRef = ref<{ flashIncorrect: () => void }>();
+const guessInputRef = ref<{
+  flashIncorrect: () => void;
+  focus: () => void;
+}>();
 const skipping = ref(false);
+
+// GuessInput's own onMounted already covers the initial mount and any
+// remount (e.g. multiplayer swapping the "waiting" panel back in once a
+// new target arrives). This covers the same-instance case: the target
+// advancing without GuessInput unmounting at all (solo, or multiplayer
+// when this player wasn't left waiting).
+watch(
+  () => store.currentCode,
+  () => {
+    guessInputRef.value?.focus();
+  },
+);
 
 // "Done" (server-confirmed) rather than a fixed timeout so the button
 // stays disabled for exactly as long as the skip request is in flight.

--- a/web/modules/countries/components/RoomLobby.vue
+++ b/web/modules/countries/components/RoomLobby.vue
@@ -53,32 +53,79 @@
         class="roomlobby-settings"
       />
 
+      <DropdownSelect
+        v-model="countryOrder"
+        label="Country order"
+        :options="countryOrderOptions"
+        class="roomlobby-settings"
+      />
+
       <LinkButton large text="Start Game" @click="startGame">
         <Icon name="bx:play" />
       </LinkButton>
     </template>
 
-    <p
-      v-else-if="!store.isHost && store.players.length > 1"
-      class="roomlobby-waiting"
-    >
-      Waiting for the host to start&hellip;
-    </p>
+    <template v-else-if="!store.isHost && store.players.length > 1">
+      <p class="roomlobby-settings-readonly">
+        Game length:
+        <span class="roomlobby-settings-value"
+          >{{ store.roundLength / 60 }} min</span
+        >
+      </p>
+      <p class="roomlobby-settings-readonly">
+        Country order:
+        <span class="roomlobby-settings-value">{{
+          countryOrderLabel
+        }}</span>
+      </p>
+      <p class="roomlobby-waiting">
+        Waiting for the host to start&hellip;
+      </p>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import isMobile from "is-mobile";
+import type { CountryOrder } from "../stores/countryGuesserRoom";
 
 const store = useCountryGuesserRoomStore();
 const copied = ref(false);
 const gameLengthMinutes = ref(5);
 const startingSolo = ref(false);
 
+const countryOrder = ref<CountryOrder>("random");
+const countryOrderOptions: { label: string; value: CountryOrder }[] =
+  [
+    { label: "Random", value: "random" },
+    { label: "Alphabetical", value: "alphabetical" },
+    { label: "Population", value: "population" },
+    { label: "Size", value: "size" },
+  ];
+
+const countryOrderLabel = computed(
+  () =>
+    countryOrderOptions.find(
+      option => option.value === store.countryOrder,
+    )?.label ?? "Random",
+);
+
+// Pushed live so a non-host player can see the host's picks as they're
+// made, not just once the round starts (see the read-only display
+// above and "update_settings" in game-room.ts, which ignores this from
+// anyone but the host).
+watch([gameLengthMinutes, countryOrder], () => {
+  store.updateSettings(
+    gameLengthMinutes.value * 60,
+    countryOrder.value,
+  );
+});
+
 function startGame() {
   store.startGame(
     gameLengthMinutes.value * 60,
     store.players.length < 2,
+    countryOrder.value,
   );
 }
 
@@ -269,6 +316,17 @@ onUnmounted(() => {
   &-waiting {
     color: var(--color-light);
     font-size: 0.9rem;
+  }
+
+  &-settings-readonly {
+    margin: 0;
+    color: var(--color-light);
+    font-size: 0.9rem;
+  }
+
+  &-settings-value {
+    color: var(--color-highlight);
+    font-weight: 600;
   }
 }
 </style>

--- a/web/modules/countries/components/ScoreBar.vue
+++ b/web/modules/countries/components/ScoreBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="scorebar">
     <span :class="['scorebar-timer', timerClass]">
-      {{ secondsLeft }}s
+      {{ timerLabel }}
     </span>
 
     <span v-if="!players" class="scorebar-progress">
@@ -52,6 +52,15 @@ const props = withDefaults(defineProps<Props>(), {
 const sortedPlayers = computed(() =>
   [...(props.players ?? [])].sort((a, b) => b.score - a.score),
 );
+
+const timerLabel = computed(() => {
+  if (props.secondsLeft < 60) {
+    return `${props.secondsLeft}s`;
+  }
+  const minutes = Math.floor(props.secondsLeft / 60);
+  const seconds = props.secondsLeft % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+});
 
 const timerClass = computed(() => {
   if (props.secondsLeft > 30) {

--- a/web/modules/countries/composables/useMapReady.ts
+++ b/web/modules/countries/composables/useMapReady.ts
@@ -1,0 +1,11 @@
+// Shared across CountryMap instances (rather than per-instance state) so
+// the page can key its dynamic-background visibility off "has any map on
+// this page rendered its first frame yet" regardless of which one is
+// currently mounted -- the lobby's AttractMap-wrapped map, or gameplay's
+// own. Never reset back to false: once the page has shown a real map
+// frame, later remounts (e.g. lobby -> gameplay) shouldn't re-flash it.
+const ready = ref(false);
+
+export function useMapReady() {
+  return ready;
+}

--- a/web/modules/countries/data/countries.ts
+++ b/web/modules/countries/data/countries.ts
@@ -4,6 +4,8 @@ export interface Country {
   code: string;
   name: string;
   aliases: string[];
+  population: number;
+  area: number;
 }
 
 export const COUNTRIES: Country[] = countriesData;

--- a/web/modules/countries/pages/countries/[room].vue
+++ b/web/modules/countries/pages/countries/[room].vue
@@ -64,7 +64,10 @@ useSeoMeta({
   ogImage: "https://markmetcalfe.com/countries-social-card.jpg?v=1",
 });
 
-useHideDynamicBackground();
+// Deferred until the map itself has actually rendered a frame (rather
+// than hiding as soon as this page mounts) so there's no gap of nothing
+// behind the still-loading map -- see useMapReady().
+useHideDynamicBackground(useMapReady());
 
 useFixMobileViewport();
 
@@ -153,6 +156,10 @@ onMounted(() => {
 
 onUnmounted(() => {
   store.disconnect();
+  // Reset for the next visit -- this is shared, page-lifetime state (see
+  // useMapReady()), not per-CountryMap-instance state, so it otherwise
+  // stays true from a previous visit and skips the defer entirely.
+  useMapReady().value = false;
 });
 </script>
 

--- a/web/modules/countries/stores/countryGuesserRoom.ts
+++ b/web/modules/countries/stores/countryGuesserRoom.ts
@@ -2,6 +2,12 @@ import { defineStore } from "pinia";
 
 export type RoomPhase = "waiting" | "playing" | "round_end";
 
+export type CountryOrder =
+  | "random"
+  | "alphabetical"
+  | "population"
+  | "size";
+
 export interface Player {
   id: string;
   name: string;
@@ -17,6 +23,7 @@ interface RoomState {
   mode: "multiplayer" | "solo";
   players: Player[];
   roundLength: number;
+  countryOrder: CountryOrder;
   timeLeft: number;
   elapsedSeconds: number;
   currentCode: string;
@@ -68,7 +75,12 @@ type ServerMessage =
   | { type: "score_submitted" }
   | { type: "error"; message: string }
   | { type: "ping" }
-  | { type: "returned_to_lobby" };
+  | { type: "returned_to_lobby" }
+  | {
+      type: "settings_update";
+      round_length: number;
+      country_order: CountryOrder;
+    };
 
 export interface RoomEvent {
   kind: "correct" | "no_guess" | "error";
@@ -157,6 +169,7 @@ export const useCountryGuesserRoomStore = defineStore(
       phase: "waiting" as RoomPhase,
       players: [] as Player[],
       roundLength: 300,
+      countryOrder: "random" as CountryOrder,
       timeLeft: 0,
       elapsedSeconds: 0,
       currentCode: "",
@@ -300,12 +313,31 @@ export const useCountryGuesserRoomStore = defineStore(
         });
       },
 
-      startGame(roundLength: number, solo = false) {
+      startGame(
+        roundLength: number,
+        solo = false,
+        countryOrder: CountryOrder = "random",
+      ) {
         this.soloMode = solo;
         this.send({
           type: "start_game",
           round_length: roundLength,
           solo,
+          country_order: countryOrder,
+        });
+      },
+
+      // Lets a non-host player see the host's picks live -- see
+      // "update_settings" in game-room.ts, which silently no-ops this
+      // for anyone else.
+      updateSettings(
+        roundLength: number,
+        countryOrder: CountryOrder,
+      ) {
+        this.send({
+          type: "update_settings",
+          round_length: roundLength,
+          country_order: countryOrder,
         });
       },
 
@@ -343,6 +375,7 @@ export const useCountryGuesserRoomStore = defineStore(
             this.soloMode = msg.state.mode === "solo";
             this.players = msg.state.players;
             this.roundLength = msg.state.roundLength;
+            this.countryOrder = msg.state.countryOrder;
             this.timeLeft = msg.state.timeLeft;
             this.elapsedSeconds = msg.state.elapsedSeconds;
             this.currentCode = msg.state.currentCode;
@@ -436,6 +469,11 @@ export const useCountryGuesserRoomStore = defineStore(
 
           case "returned_to_lobby":
             this.phase = "waiting";
+            break;
+
+          case "settings_update":
+            this.roundLength = msg.round_length;
+            this.countryOrder = msg.country_order;
             break;
 
           case "ping":

--- a/web/modules/countries/tests/e2e/country-guesser-lobby.spec.ts
+++ b/web/modules/countries/tests/e2e/country-guesser-lobby.spec.ts
@@ -165,12 +165,42 @@ test.describe("Country Guesser Lobby", () => {
         localStorage.setItem("countryGuesserHighScore", "555"),
       );
 
+      // The leaderboard is a single global Durable Object shared by every
+      // room (see LEADERBOARD.idFromName("global") in game-room.ts), so
+      // whether it already has entries by the time this test runs depends
+      // on which other tests happened to submit a score first -- on a
+      // clean backend it's genuinely empty, which left the modal showing
+      // "Loading…" (or "No scores yet") forever and made the Chromatic
+      // snapshot flaky. Mocking the response makes both the content and
+      // the load timing deterministic regardless of any other test.
+      await page.route(
+        "**/api/countries/leaderboard",
+        route =>
+          void route.fulfill({
+            json: [
+              { name: "Alex", score: 320 },
+              { name: "Sam", score: 210 },
+            ],
+          }),
+      );
+
       await joinLobby(page, "Alex");
       await page.getByRole("button", { name: "Leaderboard" }).click();
 
       await expect(
         page.getByRole("heading", { name: "Leaderboard" }),
       ).toBeVisible();
+
+      const entries = page.locator(".leaderboardmodal-entry");
+      await expect(entries).toHaveCount(2);
+      await expect(entries.nth(0)).toContainText("Alex");
+      await expect(
+        entries.nth(0).locator(".leaderboardmodal-score"),
+      ).toHaveText("320");
+      await expect(entries.nth(1)).toContainText("Sam");
+      await expect(
+        entries.nth(1).locator(".leaderboardmodal-score"),
+      ).toHaveText("210");
 
       await expect(
         page.locator(".leaderboardmodal-personal"),

--- a/web/modules/countries/tests/e2e/country-guesser-multiplayer.spec.ts
+++ b/web/modules/countries/tests/e2e/country-guesser-multiplayer.spec.ts
@@ -16,209 +16,304 @@ test.beforeEach(async ({ context }, testInfo) => {
   await isolateRoomPerFile(context, testInfo, "multiplayer");
 });
 
-// Same alphabetical-under-Playwright queue as the solo test, so
-// "Afghanistan", "Albania" and "Algeria" are always the first three
-// targets. Unlike solo, multiplayer guesses/skips carry no time
-// bonus/penalty (see game-room.ts), so there's no way to drain the
-// clock early -- the round length is set to the server's 1 minute
-// minimum. The round clock itself ticks faster under Playwright (see
-// PLAYWRIGHT_TICK_SPEEDUP in game-room.ts), so the game-over wait
-// below is roughly 1/4 of that, not a genuine 1 minute.
-testPerProject(
-  "plays a multiplayer round from an invite link through to game over, and back to the lobby",
-  async ({ page, context, browser }, testInfo) => {
-    test.setTimeout(90000);
+// Both tests below join a "Mark" + "Steve" pair into this file's shared
+// room (see isolateRoomPerFile) -- serialised so they can't both be
+// mid-join at once, which otherwise races two concurrent "Mark"s into
+// the same room.
+test.describe("Country Guesser Multiplayer", () => {
+  test.describe.configure({ mode: "serial" });
 
-    await context.grantPermissions([
-      "clipboard-read",
-      "clipboard-write",
-    ]);
-    await joinLobby(page, "Mark");
-    await page.getByRole("button", { name: "Copy Link" }).click();
-    await expect(
-      page.getByRole("button", { name: "Copied!" }),
-    ).toBeVisible();
-    const inviteUrl = await page.evaluate(() =>
-      navigator.clipboard.readText(),
-    );
+  // Same alphabetical-under-Playwright queue as the solo test, so
+  // "Afghanistan", "Albania" and "Algeria" are always the first three
+  // targets. Unlike solo, multiplayer guesses/skips carry no time
+  // bonus/penalty (see game-room.ts), so there's no way to drain the
+  // clock early -- the round length is set to the server's 1 minute
+  // minimum. The round clock itself ticks faster under Playwright (see
+  // PLAYWRIGHT_TICK_SPEEDUP in game-room.ts), so the game-over wait
+  // below is roughly 1/4 of that, not a genuine 1 minute.
+  testPerProject(
+    "plays a multiplayer round from an invite link through to game over, and back to the lobby",
+    async ({ page, context, browser }, testInfo) => {
+      test.setTimeout(90000);
 
-    // Navigates straight to the invite URL and only fills in the name --
-    // NOT joinLobby(), which starts by navigating to /countries and would
-    // create (and land the guest in) a brand new room instead of Mark's.
-    const guestContext = await browser.newContext();
-    const guestPage = await guestContext.newPage();
-    await guestPage.goto(inviteUrl);
-    await submitName(guestPage, "Steve");
+      await context.grantPermissions([
+        "clipboard-read",
+        "clipboard-write",
+      ]);
+      await joinLobby(page, "Mark");
+      await page.getByRole("button", { name: "Copy Link" }).click();
+      await expect(
+        page.getByRole("button", { name: "Copied!" }),
+      ).toBeVisible();
+      const inviteUrl = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
 
-    // Host sees both players, the host badge, and the round-length
-    // controls (a slider plus a linked numeric field) and Start Game.
-    await expect(
-      page.getByText("host", { exact: true }),
-    ).toBeVisible();
-    await expect(page.getByText("Mark")).toBeVisible();
-    await expect(page.getByText("Steve")).toBeVisible();
-    await expect(
-      page.getByRole("slider", { name: "Game length (min)" }),
-    ).toBeVisible();
-    const roundLengthInput = page.getByRole("spinbutton");
-    await expect(roundLengthInput).toBeVisible();
-    const startGameButton = page.getByRole("button", {
-      name: "Start Game",
-    });
-    await expect(startGameButton).toBeVisible();
+      // Navigates straight to the invite URL and only fills in the name --
+      // NOT joinLobby(), which starts by navigating to /countries and would
+      // create (and land the guest in) a brand new room instead of Mark's.
+      const guestContext = await browser.newContext();
+      const guestPage = await guestContext.newPage();
+      await guestPage.goto(inviteUrl);
+      await submitName(guestPage, "Steve");
 
-    // The guest sees neither -- just a waiting message.
-    await expect(
-      guestPage.getByRole("button", { name: "Start Game" }),
-    ).toBeHidden();
-    await expect(
-      guestPage.getByRole("slider", { name: "Game length (min)" }),
-    ).toBeHidden();
-    await expect(
-      guestPage.getByText("Waiting for the host to start…"),
-    ).toBeVisible();
+      // Host sees both players, the host badge, and the round-length
+      // controls (a slider plus a linked numeric field) and Start Game.
+      await expect(
+        page.getByText("host", { exact: true }),
+      ).toBeVisible();
+      await expect(page.getByText("Mark")).toBeVisible();
+      await expect(page.getByText("Steve")).toBeVisible();
+      await expect(
+        page.getByRole("slider", { name: "Game length (min)" }),
+      ).toBeVisible();
+      const roundLengthInput = page.getByRole("spinbutton");
+      await expect(roundLengthInput).toBeVisible();
+      const startGameButton = page.getByRole("button", {
+        name: "Start Game",
+      });
+      await expect(startGameButton).toBeVisible();
 
-    // Shortest possible round -- the server clamps below 1 minute anyway.
-    await roundLengthInput.fill("1");
-    await startGameButton.click();
+      // The guest sees neither -- just a waiting message.
+      await expect(
+        guestPage.getByRole("button", { name: "Start Game" }),
+      ).toBeHidden();
+      await expect(
+        guestPage.getByRole("slider", { name: "Game length (min)" }),
+      ).toBeHidden();
+      await expect(
+        guestPage.getByText("Waiting for the host to start…"),
+      ).toBeVisible();
 
-    const hostGuessInput = page.getByRole("searchbox", {
-      name: "Guess",
-    });
-    const hostGuessButton = page.getByRole("button", {
-      name: "Guess",
-    });
-    const hostSkipButton = page.getByRole("button", { name: "Skip" });
-    const guestGuessInput = guestPage.getByRole("searchbox", {
-      name: "Guess",
-    });
-    const guestGuessButton = guestPage.getByRole("button", {
-      name: "Guess",
-    });
-    const guestSkipButton = guestPage.getByRole("button", {
-      name: "Skip",
-    });
+      // Shortest possible round -- the server clamps below 1 minute anyway.
+      await roundLengthInput.fill("1");
+      await startGameButton.click();
 
-    await expect(hostGuessInput).toBeVisible();
-    await expect(guestGuessInput).toBeVisible();
-    await expect(page.locator(".scorebar-players")).toContainText(
-      "Mark",
-    );
-    await expect(page.locator(".scorebar-players")).toContainText(
-      "Steve",
-    );
+      const hostGuessInput = page.getByRole("searchbox", {
+        name: "Guess",
+      });
+      const hostGuessButton = page.getByRole("button", {
+        name: "Guess",
+      });
+      const hostSkipButton = page.getByRole("button", {
+        name: "Skip",
+      });
+      const guestGuessInput = guestPage.getByRole("searchbox", {
+        name: "Guess",
+      });
+      const guestGuessButton = guestPage.getByRole("button", {
+        name: "Guess",
+      });
+      const guestSkipButton = guestPage.getByRole("button", {
+        name: "Skip",
+      });
 
-    await waitForMapLoaded(page);
-    await takeSnapshot(
-      page,
-      "Country Guesser Multiplayer Gameplay",
-      testInfo,
-    );
+      await expect(hostGuessInput).toBeVisible();
+      await expect(guestGuessInput).toBeVisible();
+      await expect(page.locator(".scorebar-players")).toContainText(
+        "Mark",
+      );
+      await expect(page.locator(".scorebar-players")).toContainText(
+        "Steve",
+      );
 
-    // Afghanistan: both guess correctly -- each scores points (100 down
-    // to a floor of 20, depending on how many clue letters happened to
-    // be revealed before the guess landed) and the round only advances
-    // once both are done.
-    await hostGuessInput.fill("Afghanistan");
-    await clickRobustly(hostGuessButton);
-    await expect(page.locator(".guesspanel-waiting-text")).toHaveText(
-      "Nice, you got it! Waiting for Steve…",
-    );
-    await expect(guestGuessInput).toBeVisible();
+      // Unlike solo, multiplayer has no skip/guess time bonus/penalty to
+      // drive the clock with (see the comment on this describe block) --
+      // it only ever moves via the passive per-second tick, so how much
+      // it had already ticked down by snapshot time varied with how long
+      // map load and the assertions above happened to take (seen
+      // anywhere from 48s to 53s left), which Chromatic then flagged as
+      // a diff every run. Waiting for a fixed value pins it.
+      await waitForMapLoaded(page);
+      // A plain `expect(...).toHaveText("45s")` isn't tight enough to
+      // reliably catch this -- the clock ticks every 250ms (4x speed,
+      // see PLAYWRIGHT_TICK_SPEEDUP) but that assertion's own retry
+      // interval is coarser than that, so it was observed skipping
+      // straight past 45 to 44 or lower between polls. waitForFunction's
+      // default requestAnimationFrame-cadence polling is tight enough to
+      // not miss it.
+      await page.waitForFunction(
+        () =>
+          document
+            .querySelector(".scorebar-timer")
+            ?.textContent?.trim() === "45s",
+      );
+      await takeSnapshot(
+        page,
+        "Country Guesser Multiplayer Gameplay",
+        testInfo,
+      );
 
-    await guestGuessInput.fill("Afghanistan");
-    await clickRobustly(guestGuessButton);
-    await expect(hostGuessInput).toBeVisible();
-    await expect(guestGuessInput).toBeVisible();
+      // Afghanistan: both guess correctly -- each scores points (100 down
+      // to a floor of 20, 10 off per clue letter already revealed at
+      // guess time; clues never auto-reveal under Playwright though, see
+      // `clueIntervalSeconds` in game-room.ts, so this is always 100 here)
+      // and the round only advances once both are done.
+      await hostGuessInput.fill("Afghanistan");
+      await clickRobustly(hostGuessButton);
+      await expect(
+        page.locator(".guesspanel-waiting-text"),
+      ).toHaveText("Nice, you got it! Waiting for Steve…");
+      await expect(guestGuessInput).toBeVisible();
 
-    // Mark's score is now final -- he only skips from here on.
-    const markPoints = Number(
-      await page
-        .locator(".scorebar-player", { hasText: "Mark" })
-        .locator(".scorebar-player-score")
-        .innerText(),
-    );
-    expect(markPoints).toBeGreaterThanOrEqual(20);
-    expect(markPoints).toBeLessThanOrEqual(100);
+      await guestGuessInput.fill("Afghanistan");
+      await clickRobustly(guestGuessButton);
+      await expect(hostGuessInput).toBeVisible();
+      await expect(guestGuessInput).toBeVisible();
 
-    // Albania: host skips (no score change for him), guest guesses.
-    await clickRobustly(hostSkipButton);
-    await expect(page.locator(".guesspanel-waiting-text")).toHaveText(
-      "Skipped. Waiting for Steve…",
-    );
-    await guestGuessInput.fill("Albania");
-    await clickRobustly(guestGuessButton);
-    await expect(hostGuessInput).toBeVisible();
-    await expect(guestGuessInput).toBeVisible();
+      // Mark's score is now final -- he only skips from here on.
+      const markPoints = Number(
+        await page
+          .locator(".scorebar-player", { hasText: "Mark" })
+          .locator(".scorebar-player-score")
+          .innerText(),
+      );
+      expect(markPoints).toBeGreaterThanOrEqual(20);
+      expect(markPoints).toBeLessThanOrEqual(100);
 
-    // Steve's score is now final (2 correct guesses combined).
-    const stevePoints = Number(
-      await page
-        .locator(".scorebar-player", { hasText: "Steve" })
-        .locator(".scorebar-player-score")
-        .innerText(),
-    );
-    expect(stevePoints).toBeGreaterThanOrEqual(40);
-    expect(stevePoints).toBeLessThanOrEqual(200);
-    expect(stevePoints).toBeGreaterThan(markPoints);
+      // Albania: host skips (no score change for him), guest guesses.
+      await clickRobustly(hostSkipButton);
+      await expect(
+        page.locator(".guesspanel-waiting-text"),
+      ).toHaveText("Skipped. Waiting for Steve…");
+      await guestGuessInput.fill("Albania");
+      await clickRobustly(guestGuessButton);
+      await expect(hostGuessInput).toBeVisible();
+      await expect(guestGuessInput).toBeVisible();
 
-    // Algeria: guest skips first this time, then host -- no score change
-    // for either.
-    await clickRobustly(guestSkipButton);
-    await expect(
-      guestPage.locator(".guesspanel-waiting-text"),
-    ).toHaveText("Skipped. Waiting for Mark…");
-    await clickRobustly(hostSkipButton);
+      // Steve's score is now final (2 correct guesses combined).
+      const stevePoints = Number(
+        await page
+          .locator(".scorebar-player", { hasText: "Steve" })
+          .locator(".scorebar-player-score")
+          .innerText(),
+      );
+      expect(stevePoints).toBeGreaterThanOrEqual(40);
+      expect(stevePoints).toBeLessThanOrEqual(200);
+      expect(stevePoints).toBeGreaterThan(markPoints);
 
-    // Steve: 2 correct, 1 skip -- the higher score, so the winner. Mark:
-    // 1 correct, 2 skips. The rest of the round plays out untouched
-    // until the (accelerated, ~15s) clock ends it.
-    const gameOverHeading = page.getByRole("heading", {
-      name: "Game Over",
-    });
-    await expect(gameOverHeading).toBeVisible({ timeout: 45000 });
-    await expect(
-      guestPage.getByRole("heading", { name: "Game Over" }),
-    ).toBeVisible();
+      // Algeria: guest skips first this time, then host -- no score change
+      // for either.
+      await clickRobustly(guestSkipButton);
+      await expect(
+        guestPage.locator(".guesspanel-waiting-text"),
+      ).toHaveText("Skipped. Waiting for Mark…");
+      await clickRobustly(hostSkipButton);
 
-    await expect(page.locator(".gameoverscreen-winner")).toHaveText(
-      "Steve wins!",
-    );
-    const scores = page.locator(".gameoverscreen-score");
-    await expect(scores).toHaveCount(2);
-    await expect(scores.nth(0)).toContainText("Steve");
-    await expect(scores.nth(0)).toContainText("2 guessed, 1 skipped");
-    await expect(
-      scores.nth(0).locator(".gameoverscreen-score-pts"),
-    ).toHaveText(String(stevePoints));
-    await expect(scores.nth(1)).toContainText("Mark");
-    await expect(scores.nth(1)).toContainText("1 guessed, 2 skipped");
-    await expect(
-      scores.nth(1).locator(".gameoverscreen-score-pts"),
-    ).toHaveText(String(markPoints));
+      // Steve: 2 correct, 1 skip -- the higher score, so the winner. Mark:
+      // 1 correct, 2 skips. The rest of the round plays out untouched
+      // until the (accelerated, ~15s) clock ends it.
+      const gameOverHeading = page.getByRole("heading", {
+        name: "Game Over",
+      });
+      await expect(gameOverHeading).toBeVisible({ timeout: 45000 });
+      await expect(
+        guestPage.getByRole("heading", { name: "Game Over" }),
+      ).toBeVisible();
 
-    await takeSnapshot(
-      page,
-      "Country Guesser Multiplayer Game Over",
-      testInfo,
-    );
+      await expect(page.locator(".gameoverscreen-winner")).toHaveText(
+        "Steve wins!",
+      );
+      const scores = page.locator(".gameoverscreen-score");
+      await expect(scores).toHaveCount(2);
+      await expect(scores.nth(0)).toContainText("Steve");
+      await expect(scores.nth(0)).toContainText(
+        "2 guessed, 1 skipped",
+      );
+      await expect(
+        scores.nth(0).locator(".gameoverscreen-score-pts"),
+      ).toHaveText(String(stevePoints));
+      await expect(scores.nth(1)).toContainText("Mark");
+      await expect(scores.nth(1)).toContainText(
+        "1 guessed, 2 skipped",
+      );
+      await expect(
+        scores.nth(1).locator(".gameoverscreen-score-pts"),
+      ).toHaveText(String(markPoints));
 
-    const backToLobbyButton = page.getByRole("button", {
-      name: "Back to Lobby",
-    });
-    await expect(backToLobbyButton).toBeVisible();
-    await expect(
-      guestPage.getByText(
-        "Waiting for the host to return to the lobby…",
-      ),
-    ).toBeVisible();
+      await takeSnapshot(
+        page,
+        "Country Guesser Multiplayer Game Over",
+        testInfo,
+      );
 
-    await backToLobbyButton.click();
-    await expect(startGameButton).toBeVisible();
-    await expect(
-      guestPage.getByText("Waiting for the host to start…"),
-    ).toBeVisible();
+      const backToLobbyButton = page.getByRole("button", {
+        name: "Back to Lobby",
+      });
+      await expect(backToLobbyButton).toBeVisible();
+      await expect(
+        guestPage.getByText(
+          "Waiting for the host to return to the lobby…",
+        ),
+      ).toBeVisible();
 
-    await guestContext.close();
-  },
-);
+      await backToLobbyButton.click();
+      await expect(startGameButton).toBeVisible();
+      await expect(
+        guestPage.getByText("Waiting for the host to start…"),
+      ).toBeVisible();
+
+      await guestContext.close();
+    },
+  );
+
+  // Population order is sorted server-side (see queueForOrder in
+  // game-room.ts) independently of the alphabetical-under-Playwright queue
+  // the other test above relies on, and India is unambiguously the most
+  // populous country in shared/countries.json -- so it's always the very
+  // first target once this order is selected, regardless of environment.
+  testPerProject(
+    "orders the round by population when that order is selected",
+    async ({ page, context, browser }) => {
+      await context.grantPermissions([
+        "clipboard-read",
+        "clipboard-write",
+      ]);
+      await joinLobby(page, "Mark");
+      await page.getByRole("button", { name: "Copy Link" }).click();
+      await expect(
+        page.getByRole("button", { name: "Copied!" }),
+      ).toBeVisible();
+      const inviteUrl = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
+
+      const guestContext = await browser.newContext();
+      const guestPage = await guestContext.newPage();
+      await guestPage.goto(inviteUrl);
+      await submitName(guestPage, "Steve");
+
+      await page.getByLabel("Country order").click();
+      await page.getByRole("option", { name: "Population" }).click();
+
+      // A non-host player sees the host's live picks in plain text, but
+      // can't edit them (see "update_settings" in game-room.ts, which
+      // only ever accepts this from the host).
+      await expect(
+        guestPage.getByText("Game length: 5 min"),
+      ).toBeVisible();
+      await expect(
+        guestPage.getByText("Country order: Population"),
+      ).toBeVisible();
+      await expect(
+        guestPage.getByRole("combobox", { name: "Country order" }),
+      ).toHaveCount(0);
+
+      await page.getByRole("button", { name: "Start Game" }).click();
+
+      const hostGuessInput = page.getByRole("searchbox", {
+        name: "Guess",
+      });
+      await expect(hostGuessInput).toBeVisible();
+      await hostGuessInput.fill("India");
+      await clickRobustly(
+        page.getByRole("button", { name: "Guess" }),
+      );
+      await expect(
+        page.locator(".guesspanel-waiting-text"),
+      ).toHaveText("Nice, you got it! Waiting for Steve…");
+
+      await guestContext.close();
+    },
+  );
+});

--- a/web/modules/countries/tests/e2e/country-guesser-solo.spec.ts
+++ b/web/modules/countries/tests/e2e/country-guesser-solo.spec.ts
@@ -7,6 +7,7 @@ import {
   drainRoundViaSkips,
   isolateRoomPerFile,
   joinLobby,
+  skipUntilTimerUnderOneMinute,
   testPerProject,
   waitForMapLoaded,
 } from "./helpers";
@@ -44,8 +45,10 @@ testPerProject(
       "0 / 197 guessed",
     );
     await expect(page.locator(".scorebar-score")).toHaveText("0 pts");
+    // Solo rounds start at SOLO_ROUND_LENGTH (120s, see game-room.ts) --
+    // a full minute or more always displays as "M:SS".
     await expect(page.locator(".scorebar-timer")).toHaveText(
-      /^\d{2,3}s\s*$/,
+      /^\d+:\d{2}\s*$/,
     );
 
     await waitForMapLoaded(page);
@@ -63,8 +66,9 @@ testPerProject(
     );
 
     // Correct guess advances and scores points (100 down to a floor of
-    // 20, depending on how many clue letters happened to be revealed
-    // before the guess landed).
+    // 20, 10 off per clue letter already revealed at guess time; clues
+    // never auto-reveal under Playwright though, see `clueIntervalSeconds`
+    // in game-room.ts, so this is always 100 here).
     await guessInput.fill("Afghanistan");
     await guessButton.click();
     await expect(page.locator(".scorebar-progress")).toHaveText(
@@ -83,12 +87,16 @@ testPerProject(
       "1 / 197 guessed",
     );
 
+    // Once the countdown drops under a minute, the timer switches from
+    // "M:SS" back to a plain "Ns".
+    await skipUntilTimerUnderOneMinute(page, skipButton);
+
     // Drain the clock via skips (10s penalty each, solo mode) to reach
     // game over quickly instead of waiting out the full round length.
-    // The exact number of skips needed isn't fixed -- the alarm also
-    // decrements the clock once per real second regardless of skips, so
-    // it depends on how long the clicks themselves take -- so the skip
-    // count below is read back rather than asserted as a literal.
+    // The exact number of skips needed is deterministic under Playwright
+    // (see `soloClockIsManual` in game-room.ts), but is still read back
+    // rather than asserted as a literal, since it's an implementation
+    // detail of the server's clock math this test shouldn't hardcode.
     const gameOverHeading = page.getByRole("heading", {
       name: "Game Over",
     });

--- a/web/modules/countries/tests/e2e/helpers.ts
+++ b/web/modules/countries/tests/e2e/helpers.ts
@@ -138,12 +138,40 @@ export async function clickRobustly(locator: Locator) {
   }
 }
 
-// Repeatedly skips until the round ends, checking before each click
-// rather than firing a fixed count -- the server's alarm decrements the
-// clock once per real second independent of skips, so how many skips
-// it actually takes depends on how long the clicks themselves take,
-// which varies with test-runner speed. Bounded so a genuine bug can't
-// spin forever.
+// Repeatedly skips until the countdown drops under a minute (solo's 10s
+// skip penalty makes this reliably reachable). The number of skips this
+// takes is deterministic under Playwright (see `soloClockIsManual` in
+// game-room.ts, which stops the passive per-second tick from racing
+// these clicks), but this still checks before each click rather than
+// firing a fixed count, since the exact figure is an implementation
+// detail of the server's clock math this test shouldn't hardcode.
+export async function skipUntilTimerUnderOneMinute(
+  page: Page,
+  skipButton: Locator,
+) {
+  const timer = page.locator(".scorebar-timer");
+  for (let i = 0; i < 20; i++) {
+    if (
+      /^\d{1,2}s\s*$/.test(((await timer.textContent()) ?? "").trim())
+    ) {
+      return;
+    }
+    try {
+      await skipButton.click({ timeout: 2000 });
+    } catch {
+      // Ignored -- same rationale as drainRoundViaSkips below.
+    }
+  }
+  await expect(timer).toHaveText(/^\d{1,2}s\s*$/);
+}
+
+// Repeatedly skips until the round ends. Solo's clock under Playwright
+// only moves via skip/guess actions (see `soloClockIsManual` in
+// game-room.ts), so the number of skips this takes is deterministic --
+// still checked before each click rather than fired as a fixed count,
+// since that exact figure is an implementation detail of the server's
+// clock math this test shouldn't hardcode. Bounded so a genuine bug
+// can't spin forever.
 export async function drainRoundViaSkips(
   skipButton: Locator,
   gameOverHeading: Locator,


### PR DESCRIPTION
## Summary
- Autofocus the guess input on desktop when a new target loads (already worked on mobile)
- Show the round timer as `M:SS` once a minute or more remains, plain seconds under that
- Add a multiplayer lobby setting to order the round's countries by Random, Alphabetical, Population, or Size (land area) — population/area data added to `shared/countries.json`, sourced from the World Bank API and the mledoze/countries dataset
- Defer hiding the dynamic background until the map has actually rendered its first frame, instead of on page mount, avoiding a flash of nothing while it loads
- Fixed a real accessibility gap in `DropdownSelect.vue` along the way: its `<label for>` wasn't wired to the combobox via `aria-labelledby`, so it had no accessible name

## Test plan
- [x] `npm run typecheck` (web + api)
- [x] `npm run lint` (web + api)
- [x] Full `web/modules/countries/tests/e2e/` suite, both Desktop Chrome and Mobile Chrome projects — all passing except one pre-existing, load-sensitive Mobile Chrome multiplayer flake (confirmed unrelated by re-running it in isolation, where it passes)
- [x] New multiplayer test verifies selecting "Population" order makes India (most populous) the first target
- [x] Solo test updated/extended to cover both the `M:SS` and plain-seconds timer formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)